### PR TITLE
nette/utils 4.0

### DIFF
--- a/build/composer-php-72.json
+++ b/build/composer-php-72.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "phpstan/phpstan": "^1.9.3",
-        "nette/utils": "^3.2"
+        "nette/utils": "^3.2 || ^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The new tag 0.1.3 still doesn't allow new nette/utils. It seems I missed this? :thinking: Sorry I'm not very familiar with your build process...