### PR TITLE
Improve error message with exact filled-type count and single decimal relatives

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "phpunit/phpunit": "^10.3",
         "symplify/easy-coding-standard": "^12.0",
         "rector/rector": "^0.18",
-        "tracy/tracy": "^2.9",
+        "tracy/tracy": "^2.10",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "tomasvotruba/unused-public": "^0.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,16 +6,16 @@
     "keywords": ["static analysis", "phpstan-extension"],
     "require": {
         "php": "^8.1",
-        "phpstan/phpstan": "^1.10.3"
+        "phpstan/phpstan": "^1.10"
     },
     "require-dev": {
         "phpstan/extension-installer": "^1.3",
-        "phpunit/phpunit": "^10.1",
-        "symplify/easy-coding-standard": "^11.3",
-        "rector/rector": "^0.16",
+        "phpunit/phpunit": "^10.3",
+        "symplify/easy-coding-standard": "^12.0",
+        "rector/rector": "^0.18",
         "tracy/tracy": "^2.9",
         "php-parallel-lint/php-parallel-lint": "^1.3",
-        "tomasvotruba/unused-public": "^0.1.10"
+        "tomasvotruba/unused-public": "^0.2"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,6 +8,11 @@ parameters:
         - src
         - tests
 
+    type_coverage:
+        return_type: 100
+        param_type: 100
+        property_type: 100
+
     checkGenericClassInNonGenericObjectType: false
 
     excludePaths:

--- a/rector.php
+++ b/rector.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
-use Rector\CodingStyle\Rector\ClassConst\VarConstantCommentRector;
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
@@ -30,9 +28,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->skip([
         '*/Fixture/*',
         '*/Source/*',
-
-        VarConstantCommentRector::class => [
-            __DIR__ . '/src/PublicClassMethodMatcher.php',
-        ],
     ]);
 };

--- a/src/CollectorDataNormalizer.php
+++ b/src/CollectorDataNormalizer.php
@@ -9,17 +9,20 @@ use TomasVotruba\TypeCoverage\ValueObject\TypeCountAndMissingTypes;
 final class CollectorDataNormalizer
 {
     /**
-     * @param mixed[] $collectorDataByPath
+     * @param array<string, array<array{0: int, 1: array<string, int>}>> $collectorDataByPath
      */
     public function normalize(array $collectorDataByPath): TypeCountAndMissingTypes
     {
         $totalCount = 0;
+        $missingCount = 0;
 
         $missingTypeLinesByFilePath = [];
 
-        foreach ($collectorDataByPath as $filePath => $returnSeaLevelData) {
-            foreach ($returnSeaLevelData as $nestedData) {
+        foreach ($collectorDataByPath as $filePath => $typeCoverageData) {
+            foreach ($typeCoverageData as $nestedData) {
                 $totalCount += $nestedData[0];
+
+                $missingCount += count($nestedData[1]);
 
                 $missingTypeLinesByFilePath[$filePath] = array_merge(
                     $missingTypeLinesByFilePath[$filePath] ?? [],
@@ -28,6 +31,6 @@ final class CollectorDataNormalizer
             }
         }
 
-        return new TypeCountAndMissingTypes($totalCount, $missingTypeLinesByFilePath);
+        return new TypeCountAndMissingTypes($totalCount, $missingCount, $missingTypeLinesByFilePath);
     }
 }

--- a/src/Collectors/ParamTypeDeclarationCollector.php
+++ b/src/Collectors/ParamTypeDeclarationCollector.php
@@ -42,7 +42,6 @@ final class ParamTypeDeclarationCollector implements Collector
 
             if ($param->type === null) {
                 $missingTypeLines[] = $param->getLine();
-                continue;
             }
         }
 

--- a/src/Formatter/TypeCoverageFormatter.php
+++ b/src/Formatter/TypeCoverageFormatter.php
@@ -35,6 +35,7 @@ final class TypeCoverageFormatter
             $errorMessage = sprintf(
                 $message,
                 $typeCountAndMissingTypes->getTotalCount(),
+                $typeCountAndMissingTypes->getFilledCount(),
                 $typeCoveragePercentage,
                 $minimalLevel
             );

--- a/src/Rules/ParamTypeCoverageRule.php
+++ b/src/Rules/ParamTypeCoverageRule.php
@@ -23,7 +23,7 @@ final class ParamTypeCoverageRule implements Rule
     /**
      * @var string
      */
-    public const ERROR_MESSAGE = 'Out of %d possible param types, only %f %% actually have it. Add more param types to get over %d %%';
+    public const ERROR_MESSAGE = 'Out of %d possible param types, only %d - %.1f %% actually have it. Add more param types to get over %d %%';
 
     public function __construct(
         private readonly TypeCoverageFormatter $typeCoverageFormatter,

--- a/src/Rules/ParamTypeCoverageRule.php
+++ b/src/Rules/ParamTypeCoverageRule.php
@@ -23,7 +23,7 @@ final class ParamTypeCoverageRule implements Rule
     /**
      * @var string
      */
-    public const ERROR_MESSAGE = 'Out of %d possible param types, only %d %% actually have it. Add more param types to get over %d %%';
+    public const ERROR_MESSAGE = 'Out of %d possible param types, only %f %% actually have it. Add more param types to get over %d %%';
 
     public function __construct(
         private readonly TypeCoverageFormatter $typeCoverageFormatter,

--- a/src/Rules/PropertyTypeCoverageRule.php
+++ b/src/Rules/PropertyTypeCoverageRule.php
@@ -23,7 +23,7 @@ final class PropertyTypeCoverageRule implements Rule
     /**
      * @var string
      */
-    public const ERROR_MESSAGE = 'Out of %d possible property types, only %d %% actually have it. Add more property types to get over %d %%';
+    public const ERROR_MESSAGE = 'Out of %d possible property types, only %d - %.1f %% actually have it. Add more property types to get over %d %%';
 
     public function __construct(
         private readonly TypeCoverageFormatter $typeCoverageFormatter,

--- a/src/Rules/ReturnTypeCoverageRule.php
+++ b/src/Rules/ReturnTypeCoverageRule.php
@@ -23,7 +23,7 @@ final class ReturnTypeCoverageRule implements Rule
     /**
      * @var string
      */
-    public const ERROR_MESSAGE = 'Out of %d possible return types, only %d %% actually have it. Add more return types to get over %d %%';
+    public const ERROR_MESSAGE = 'Out of %d possible return types, only %d - %.1f %% actually have it. Add more return types to get over %d %%';
 
     public function __construct(
         private readonly TypeCoverageFormatter $typeCoverageFormatter,

--- a/src/ValueObject/TypeCountAndMissingTypes.php
+++ b/src/ValueObject/TypeCountAndMissingTypes.php
@@ -11,6 +11,7 @@ final class TypeCountAndMissingTypes
      */
     public function __construct(
         private readonly int $totalCount,
+        private readonly int $missingCount,
         private readonly array $missingTypeLinesByFilePath
     ) {
     }
@@ -18,6 +19,11 @@ final class TypeCountAndMissingTypes
     public function getTotalCount(): int
     {
         return $this->totalCount;
+    }
+
+    public function getFilledCount(): int
+    {
+        return $this->totalCount - $this->missingCount;
     }
 
     /**
@@ -28,9 +34,9 @@ final class TypeCountAndMissingTypes
         return $this->missingTypeLinesByFilePath;
     }
 
-    public function getCoveragePercentage(): int
+    public function getCoveragePercentage(): float
     {
-        return (int) (100 * ($this->getTypedCount() / $this->totalCount));
+        return 100 * ($this->getTypedCount() / $this->totalCount);
     }
 
     private function getTypedCount(): int

--- a/tests/Rules/ParamTypeCoverageRule/Fixture/UnknownParamType.php
+++ b/tests/Rules/ParamTypeCoverageRule/Fixture/UnknownParamType.php
@@ -6,7 +6,7 @@ namespace TomasVotruba\TypeCoverage\Tests\Rules\ParamTypeCoverageRule\Fixture;
 
 final class UnknownParamType
 {
-    public function run($name, $age)
+    public function run(string $name, $age)
     {
     }
 

--- a/tests/Rules/ParamTypeCoverageRule/ParamTypeCoverageRuleTest.php
+++ b/tests/Rules/ParamTypeCoverageRule/ParamTypeCoverageRuleTest.php
@@ -30,9 +30,10 @@ final class ParamTypeCoverageRuleTest extends RuleTestCase
         yield [[__DIR__ . '/Fixture/SkipVariadic.php'], []];
         yield [[__DIR__ . '/Fixture/SkipCallableParam.php'], []];
 
-        $firstErrorMessage = sprintf(ParamTypeCoverageRule::ERROR_MESSAGE, 3, 0, 80);
-        $secondErrorMessage = sprintf(ParamTypeCoverageRule::ERROR_MESSAGE, 3, 0, 80);
-        $thirdErrorMessage = sprintf(ParamTypeCoverageRule::ERROR_MESSAGE, 3, 0, 80);
+        $firstErrorMessage = sprintf(ParamTypeCoverageRule::ERROR_MESSAGE, 3, 0, 80.0);
+        $secondErrorMessage = sprintf(ParamTypeCoverageRule::ERROR_MESSAGE, 3, 0, 80.0);
+        $thirdErrorMessage = sprintf(ParamTypeCoverageRule::ERROR_MESSAGE, 3, 0, 80.0);
+
         yield [[__DIR__ . '/Fixture/UnknownParamType.php'], [
             [$firstErrorMessage, 9],
             [$secondErrorMessage, 9],

--- a/tests/Rules/ParamTypeCoverageRule/ParamTypeCoverageRuleTest.php
+++ b/tests/Rules/ParamTypeCoverageRule/ParamTypeCoverageRuleTest.php
@@ -30,15 +30,10 @@ final class ParamTypeCoverageRuleTest extends RuleTestCase
         yield [[__DIR__ . '/Fixture/SkipVariadic.php'], []];
         yield [[__DIR__ . '/Fixture/SkipCallableParam.php'], []];
 
-        $firstErrorMessage = sprintf(ParamTypeCoverageRule::ERROR_MESSAGE, 3, 0, 80.0);
-        $secondErrorMessage = sprintf(ParamTypeCoverageRule::ERROR_MESSAGE, 3, 0, 80.0);
-        $thirdErrorMessage = sprintf(ParamTypeCoverageRule::ERROR_MESSAGE, 3, 0, 80.0);
+        $firstErrorMessage = sprintf(ParamTypeCoverageRule::ERROR_MESSAGE, 3, 1, 33.3, 80);
+        $thirdErrorMessage = sprintf(ParamTypeCoverageRule::ERROR_MESSAGE, 3, 1, 33.3, 80);
 
-        yield [[__DIR__ . '/Fixture/UnknownParamType.php'], [
-            [$firstErrorMessage, 9],
-            [$secondErrorMessage, 9],
-            [$thirdErrorMessage, 13],
-        ]];
+        yield [[__DIR__ . '/Fixture/UnknownParamType.php'], [[$firstErrorMessage, 9], [$thirdErrorMessage, 13]]];
     }
 
     /**

--- a/tests/Rules/PropertyTypeCoverageRule/Fixture/SkipCallableProperty.php
+++ b/tests/Rules/PropertyTypeCoverageRule/Fixture/SkipCallableProperty.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TomasVotruba\TypeCoverage\PropertyTypeCoverageRule\Fixture;
+namespace TomasVotruba\TypeCoverage\Tests\Rules\PropertyTypeCoverageRule\Fixture;
 
 final class SkipCallableProperty
 {

--- a/tests/Rules/PropertyTypeCoverageRule/Fixture/SkipKnownPropertyType.php
+++ b/tests/Rules/PropertyTypeCoverageRule/Fixture/SkipKnownPropertyType.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TomasVotruba\TypeCoverage\PropertyTypeCoverageRule\Fixture;
+namespace TomasVotruba\TypeCoverage\Tests\Rules\PropertyTypeCoverageRule\Fixture;
 
 final class SkipKnownPropertyType
 {

--- a/tests/Rules/PropertyTypeCoverageRule/Fixture/SkipParentBlockingProperty.php
+++ b/tests/Rules/PropertyTypeCoverageRule/Fixture/SkipParentBlockingProperty.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TomasVotruba\TypeCoverage\PropertyTypeCoverageRule\Fixture;
+namespace TomasVotruba\TypeCoverage\Tests\Rules\PropertyTypeCoverageRule\Fixture;
 
 use TomasVotruba\TypeCoverage\Tests\Rules\PropertyTypeCoverageRule\Source\ParentBlockingClass;
 

--- a/tests/Rules/PropertyTypeCoverageRule/Fixture/SkipResource.php
+++ b/tests/Rules/PropertyTypeCoverageRule/Fixture/SkipResource.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TomasVotruba\TypeCoverage\PropertyTypeCoverageRule\Fixture;
+namespace TomasVotruba\TypeCoverage\Tests\Rules\PropertyTypeCoverageRule\Fixture;
 
 final class SkipResource
 {

--- a/tests/Rules/PropertyTypeCoverageRule/Fixture/UnknownPropertyType.php
+++ b/tests/Rules/PropertyTypeCoverageRule/Fixture/UnknownPropertyType.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace TomasVotruba\TypeCoverage\PropertyTypeCoverageRule\Fixture;
+namespace TomasVotruba\TypeCoverage\Tests\Rules\PropertyTypeCoverageRule\Fixture;
 
 final class UnknownPropertyType
 {
     public $name;
 
-    public $surname;
+    public string $surname;
 }

--- a/tests/Rules/PropertyTypeCoverageRule/PropertyTypeCoverageRuleTest.php
+++ b/tests/Rules/PropertyTypeCoverageRule/PropertyTypeCoverageRuleTest.php
@@ -31,8 +31,8 @@ final class PropertyTypeCoverageRuleTest extends RuleTestCase
         yield [[__DIR__ . '/Fixture/SkipResource.php'], []];
         yield [[__DIR__ . '/Fixture/SkipParentBlockingProperty.php'], []];
 
-        $errorMessage = sprintf(PropertyTypeCoverageRule::ERROR_MESSAGE, 2, 0, 80);
-        yield [[__DIR__ . '/Fixture/UnknownPropertyType.php'], [[$errorMessage, 9], [$errorMessage, 11]]];
+        $errorMessage = sprintf(PropertyTypeCoverageRule::ERROR_MESSAGE, 2, 1, 50.0, 80);
+        yield [[__DIR__ . '/Fixture/UnknownPropertyType.php'], [[$errorMessage, 9]]];
     }
 
     /**

--- a/tests/Rules/ReturnTypeCoverageRule/ReturnTypeCoverageRuleTest.php
+++ b/tests/Rules/ReturnTypeCoverageRule/ReturnTypeCoverageRuleTest.php
@@ -29,7 +29,7 @@ final class ReturnTypeCoverageRuleTest extends RuleTestCase
         yield [[__DIR__ . '/Fixture/SkipKnownReturnType.php', __DIR__ . '/Fixture/SkipAgainKnownReturnType.php'], []];
         yield [[__DIR__ . '/Fixture/SkipConstructor.php'], []];
 
-        $errorMessage = sprintf(ReturnTypeCoverageRule::ERROR_MESSAGE, 2, 0, 80);
+        $errorMessage = sprintf(ReturnTypeCoverageRule::ERROR_MESSAGE, 2, 0, 0, 80);
         yield [[__DIR__ . '/Fixture/UnknownReturnType.php'], [[$errorMessage, 9], [$errorMessage, 13]]];
     }
 


### PR DESCRIPTION
Sometimes, we get errors like "out of 4000 types, only 89 % have it. Get over 90 %". We want to work on type coverage improvemnt, but don't know if it's 89.1 or 89.9. Should we add 10 or 80 types? This could be frustrating, moreover when the information is there.

That's why I improve the errors message, to be more precise and motivating :hugs: 

<br>

## Before

![before](https://github.com/TomasVotruba/type-coverage/assets/924196/f4f1e1fe-c538-4a5a-9f01-11d2c4536a4b)

<br>

## After

![after](https://github.com/TomasVotruba/type-coverage/assets/924196/e81846b4-a0ff-41a3-955d-0aa59394bd41)
