### PR TITLE
improvement: move stats into hints

### DIFF
--- a/src/Formatter/TypeCoverageFormatter.php
+++ b/src/Formatter/TypeCoverageFormatter.php
@@ -15,6 +15,7 @@ final class TypeCoverageFormatter
      */
     public function formatErrors(
         string $message,
+        string $tip,
         int $minimalLevel,
         TypeCountAndMissingTypes $typeCountAndMissingTypes
     ): array {
@@ -32,8 +33,8 @@ final class TypeCoverageFormatter
         $ruleErrors = [];
 
         foreach ($typeCountAndMissingTypes->getMissingTypeLinesByFilePath() as $filePath => $lines) {
-            $errorMessage = sprintf(
-                $message,
+            $tipMessage = sprintf(
+                $tip,
                 $typeCountAndMissingTypes->getTotalCount(),
                 $typeCountAndMissingTypes->getFilledCount(),
                 $typeCoveragePercentage,
@@ -41,10 +42,12 @@ final class TypeCoverageFormatter
             );
 
             foreach ($lines as $line) {
-                $ruleErrors[] = RuleErrorBuilder::message($errorMessage)
+                $ruleErrors[] = RuleErrorBuilder::message($message)
                     ->file($filePath)
                     ->line($line)
-                    ->build();
+                    ->addTip($tipMessage)
+                    ->build()
+                ;
             }
         }
 

--- a/src/Rules/ParamTypeCoverageRule.php
+++ b/src/Rules/ParamTypeCoverageRule.php
@@ -23,7 +23,12 @@ final class ParamTypeCoverageRule implements Rule
     /**
      * @var string
      */
-    public const ERROR_MESSAGE = 'Out of %d possible param types, only %d - %.1f %% actually have it. Add more param types to get over %d %%';
+    public const ERROR_MESSAGE = 'missing param type';
+
+    /**
+     * @var string
+     */
+    public const TIP_MESSAGE = 'Out of %d possible param types, only %d - %.1f %% actually have it. Add more param types to get over %d %%';
 
     public function __construct(
         private readonly TypeCoverageFormatter $typeCoverageFormatter,
@@ -56,6 +61,7 @@ final class ParamTypeCoverageRule implements Rule
 
         return $this->typeCoverageFormatter->formatErrors(
             self::ERROR_MESSAGE,
+            self::TIP_MESSAGE,
             $this->configuration->getRequiredParamTypeLevel(),
             $typeCountAndMissingTypes
         );

--- a/src/Rules/PropertyTypeCoverageRule.php
+++ b/src/Rules/PropertyTypeCoverageRule.php
@@ -23,7 +23,12 @@ final class PropertyTypeCoverageRule implements Rule
     /**
      * @var string
      */
-    public const ERROR_MESSAGE = 'Out of %d possible property types, only %d - %.1f %% actually have it. Add more property types to get over %d %%';
+    public const ERROR_MESSAGE = 'missing property type';
+
+    /**
+     * @var string
+     */
+    public const TIP_MESSAGE = 'Out of %d possible property types, only %d - %.1f %% actually have it. Add more property types to get over %d %%';
 
     public function __construct(
         private readonly TypeCoverageFormatter $typeCoverageFormatter,
@@ -55,6 +60,7 @@ final class PropertyTypeCoverageRule implements Rule
 
         return $this->typeCoverageFormatter->formatErrors(
             self::ERROR_MESSAGE,
+            self::TIP_MESSAGE,
             $this->configuration->getRequiredPropertyTypeLevel(),
             $typeCountAndMissingTypes
         );

--- a/src/Rules/ReturnTypeCoverageRule.php
+++ b/src/Rules/ReturnTypeCoverageRule.php
@@ -23,7 +23,12 @@ final class ReturnTypeCoverageRule implements Rule
     /**
      * @var string
      */
-    public const ERROR_MESSAGE = 'Out of %d possible return types, only %d - %.1f %% actually have it. Add more return types to get over %d %%';
+    public const ERROR_MESSAGE = 'missing return type';
+
+    /**
+     * @var string
+     */
+    public const TIP_MESSAGE = 'Out of %d possible return types, only %d - %.1f %% actually have it. Add more return types to get over %d %%';
 
     public function __construct(
         private readonly TypeCoverageFormatter $typeCoverageFormatter,
@@ -51,6 +56,7 @@ final class ReturnTypeCoverageRule implements Rule
 
         return $this->typeCoverageFormatter->formatErrors(
             self::ERROR_MESSAGE,
+            self::TIP_MESSAGE,
             $this->configuration->getRequiredReturnTypeLevel(),
             $typeCountAndMissingTypes
         );

--- a/tests/Rules/ParamTypeCoverageRule/ParamTypeCoverageRuleTest.php
+++ b/tests/Rules/ParamTypeCoverageRule/ParamTypeCoverageRuleTest.php
@@ -30,10 +30,13 @@ final class ParamTypeCoverageRuleTest extends RuleTestCase
         yield [[__DIR__ . '/Fixture/SkipVariadic.php'], []];
         yield [[__DIR__ . '/Fixture/SkipCallableParam.php'], []];
 
-        $firstErrorMessage = sprintf(ParamTypeCoverageRule::ERROR_MESSAGE, 3, 1, 33.3, 80);
-        $thirdErrorMessage = sprintf(ParamTypeCoverageRule::ERROR_MESSAGE, 3, 1, 33.3, 80);
+        $firstTipMessage = sprintf(ParamTypeCoverageRule::TIP_MESSAGE, 3, 1, 33.3, 80);
+        $thirdTipMessage = sprintf(ParamTypeCoverageRule::TIP_MESSAGE, 3, 1, 33.3, 80);
 
-        yield [[__DIR__ . '/Fixture/UnknownParamType.php'], [[$firstErrorMessage, 9], [$thirdErrorMessage, 13]]];
+        yield [[__DIR__ . '/Fixture/UnknownParamType.php'], [
+            [ParamTypeCoverageRule::ERROR_MESSAGE, 9, $firstTipMessage],
+            [ParamTypeCoverageRule::ERROR_MESSAGE, 13, $thirdTipMessage]
+        ]];
     }
 
     /**

--- a/tests/Rules/PropertyTypeCoverageRule/PropertyTypeCoverageRuleTest.php
+++ b/tests/Rules/PropertyTypeCoverageRule/PropertyTypeCoverageRuleTest.php
@@ -31,8 +31,8 @@ final class PropertyTypeCoverageRuleTest extends RuleTestCase
         yield [[__DIR__ . '/Fixture/SkipResource.php'], []];
         yield [[__DIR__ . '/Fixture/SkipParentBlockingProperty.php'], []];
 
-        $errorMessage = sprintf(PropertyTypeCoverageRule::ERROR_MESSAGE, 2, 1, 50.0, 80);
-        yield [[__DIR__ . '/Fixture/UnknownPropertyType.php'], [[$errorMessage, 9]]];
+        $tipMessage = sprintf(PropertyTypeCoverageRule::TIP_MESSAGE, 2, 1, 50.0, 80);
+        yield [[__DIR__ . '/Fixture/UnknownPropertyType.php'], [[PropertyTypeCoverageRule::ERROR_MESSAGE, 9, $tipMessage]]];
     }
 
     /**

--- a/tests/Rules/ReturnTypeCoverageRule/ReturnTypeCoverageRuleTest.php
+++ b/tests/Rules/ReturnTypeCoverageRule/ReturnTypeCoverageRuleTest.php
@@ -29,8 +29,11 @@ final class ReturnTypeCoverageRuleTest extends RuleTestCase
         yield [[__DIR__ . '/Fixture/SkipKnownReturnType.php', __DIR__ . '/Fixture/SkipAgainKnownReturnType.php'], []];
         yield [[__DIR__ . '/Fixture/SkipConstructor.php'], []];
 
-        $errorMessage = sprintf(ReturnTypeCoverageRule::ERROR_MESSAGE, 2, 0, 0, 80);
-        yield [[__DIR__ . '/Fixture/UnknownReturnType.php'], [[$errorMessage, 9], [$errorMessage, 13]]];
+        $tipMsg = sprintf(ReturnTypeCoverageRule::TIP_MESSAGE, 2, 0, 0, 80);
+        yield [[__DIR__ . '/Fixture/UnknownReturnType.php'], [
+            [ReturnTypeCoverageRule::ERROR_MESSAGE, 9, $tipMsg],
+            [ReturnTypeCoverageRule::ERROR_MESSAGE, 13, $tipMsg]
+        ]];
     }
 
     /**


### PR DESCRIPTION
heyho,

background: 
we use a central configuration for multiple projects with working with phpstan, we seldom have specific target values.
in fact, most of the time we just set the target to `100` and move errors into the baseline.

```yaml
    type_coverage:
        return_type: 100
        param_type: 100
        property_type: 100
```

so i was thinking of how to deal with reported errors and the baseline in this context and figured, it would be better to move statistics into the hint portion. at the moment, we will get reports looking like this:
```
------ --------------------------------------------------------------------------------------------------------
  Line   N/A
 ------ --------------------------------------------------------------------------------------------------------
  -1     Out of 1 possible param types, only 0 % actually have it. Add more param types to get over 100 %
  -1     Out of 1 possible property types, only 0 % actually have it. Add more property types to get over 100 %
  -1     Out of 1 possible return types, only 0 % actually have it. Add more return types to get over 100 %
 ------ --------------------------------------------------------------------------------------------------------
```

if we ignore the errors via the baseline, we'll end up with a baseline like this:
```yaml
parameters:
    ignoreErrors:
        -
            message: "#^Out of 1 possible param types, only 0 %% actually have it\\. Add more param types to get over 100 %%$#"
            count: 1
            path: N/A

        -
            message: "#^Out of 1 possible property types, only 0 %% actually have it\\. Add more property types to get over 100 %%$#"
            count: 1
            path: N/A

        -
            message: "#^Out of 1 possible return types, only 0 %% actually have it\\. Add more return types to get over 100 %%$#"
            count: 1
            path: N/A
```

so if we now make a change to our code, all those errors popping up again with different percentages and numbers.
so i propose to use phpstans hints instead for the stats, since they do not end up in the baseline:

this PR will produce reports like this:

```
 ------ -----------------------------------------------------------------------------------------------------------------
  Line   index.php
 ------ -----------------------------------------------------------------------------------------------------------------
  6      missing property type
         💡 Out of 1 possible property types, only 0 - 0.0 % actually have it. Add more property types to get over 100 %
  12     missing param type
         💡 Out of 1 possible param types, only 0 - 0.0 % actually have it. Add more param types to get over 100 %
  12     missing return type
         💡 Out of 1 possible return types, only 0 - 0.0 % actually have it. Add more return types to get over 100 %
 ------ -----------------------------------------------------------------------------------------------------------------
```

and a baseline like this:

```yaml
parameters:
    ignoreErrors:
        -
            message: "#^missing param type$#"
            count: 1
            path: src/index.php

        -
            message: "#^missing property type$#"
            count: 1
            path: src/index.php

        -
            message: "#^missing return type$#"
            count: 1
            path: src/index.php
```

what do you thing?

in theory, you could just omit the target-percentages with this change and always assume 100% and use the baseline instead :thinking: 
but i did not touch that part for now.