### PR TITLE
Do not require return type for renamed trait constructor [close #23]

### DIFF
--- a/src/Collectors/ReturnTypeDeclarationCollector.php
+++ b/src/Collectors/ReturnTypeDeclarationCollector.php
@@ -30,6 +30,13 @@ final class ReturnTypeDeclarationCollector implements Collector
             return null;
         }
 
+		if ($scope->isInTrait()) {
+			$originalMethodName = $node->getAttribute('originalTraitMethodName');
+			if ($originalMethodName === '__construct') {
+				return null;
+			}
+		}
+
         $missingTypeLines = [];
 
         if (! $node->returnType instanceof Node) {

--- a/tests/Rules/ReturnTypeCoverageRule/Fixture/SkipTraitConstructor.php
+++ b/tests/Rules/ReturnTypeCoverageRule/Fixture/SkipTraitConstructor.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\TypeCoverage\Tests\Rules\ReturnTypeCoverageRule\Fixture;
+
+final class SkipTraitConstructor
+{
+    use TraitWithConstructor {
+		TraitWithConstructor::__construct as traitConstruct;
+    }
+
+    public function __construct()
+    {
+        $this->traitConstruct();
+    }
+}
+
+trait TraitWithConstructor
+{
+    public function __construct()
+    {
+    }
+}

--- a/tests/Rules/ReturnTypeCoverageRule/ReturnTypeCoverageRuleTest.php
+++ b/tests/Rules/ReturnTypeCoverageRule/ReturnTypeCoverageRuleTest.php
@@ -28,6 +28,7 @@ final class ReturnTypeCoverageRuleTest extends RuleTestCase
     {
         yield [[__DIR__ . '/Fixture/SkipKnownReturnType.php', __DIR__ . '/Fixture/SkipAgainKnownReturnType.php'], []];
         yield [[__DIR__ . '/Fixture/SkipConstructor.php'], []];
+        yield [[__DIR__ . '/Fixture/SkipTraitConstructor.php'], []];
 
         $errorMessage = sprintf(ReturnTypeCoverageRule::ERROR_MESSAGE, 2, 0, 0, 80);
         yield [[__DIR__ . '/Fixture/UnknownReturnType.php'], [[$errorMessage, 9], [$errorMessage, 13]]];


### PR DESCRIPTION
closes #23 
solved in phpstan in https://github.com/phpstan/phpstan/issues/9571 and https://github.com/phpstan/phpstan-src/commit/f6ca9c88d66af8d272e4baec19dbd63a0ec54a5f