### PR TITLE
Fixes the error message for param and property types

### DIFF
--- a/src/Rules/ParamTypeCoverageRule.php
+++ b/src/Rules/ParamTypeCoverageRule.php
@@ -23,7 +23,7 @@ final readonly class ParamTypeCoverageRule implements Rule
     /**
      * @var string
      */
-    public const ERROR_MESSAGE = 'Out of %d possible param types, only %d - %.1f %% actually have it. Add more param types to get over %d %%';
+    public const ERROR_MESSAGE = 'Out of %d possible param types, only %d - %.1f %% actually have it. Add more param types to get over %s %%';
 
     public function __construct(
         private TypeCoverageFormatter $typeCoverageFormatter,

--- a/src/Rules/PropertyTypeCoverageRule.php
+++ b/src/Rules/PropertyTypeCoverageRule.php
@@ -23,7 +23,7 @@ final readonly class PropertyTypeCoverageRule implements Rule
     /**
      * @var string
      */
-    public const ERROR_MESSAGE = 'Out of %d possible property types, only %d - %.1f %% actually have it. Add more property types to get over %d %%';
+    public const ERROR_MESSAGE = 'Out of %d possible property types, only %d - %.1f %% actually have it. Add more property types to get over %s %%';
 
     public function __construct(
         private TypeCoverageFormatter $typeCoverageFormatter,


### PR DESCRIPTION
Applies the same fix applied to the return type coverage error message in https://github.com/TomasVotruba/type-coverage/pull/31 to the param and property type coverage rules