### PR TITLE
Update for PHPStan 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "keywords": ["static analysis", "phpstan-extension"],
     "require": {
         "php": "^8.2",
-        "phpstan/phpstan": "^1.10.67"
+        "phpstan/phpstan": "^2.0"
     },
     "require-dev": {
         "phpstan/extension-installer": "^1.3",

--- a/tests/Rules/ConstantTypeCoverageRule/ConstantTypeCoverageRuleTest.php
+++ b/tests/Rules/ConstantTypeCoverageRule/ConstantTypeCoverageRuleTest.php
@@ -23,7 +23,7 @@ final class ConstantTypeCoverageRuleTest extends RuleTestCase
 
     /**
      * @param string[] $filePaths
-     * @param mixed[] $expectedErrorsWithLines
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorsWithLines
      */
     #[DataProvider('provideData')]
     public function testRule(array $filePaths, array $expectedErrorsWithLines): void

--- a/tests/Rules/DeclareCoverageRule/DeclareCoverageRuleTest.php
+++ b/tests/Rules/DeclareCoverageRule/DeclareCoverageRuleTest.php
@@ -16,7 +16,7 @@ final class DeclareCoverageRuleTest extends RuleTestCase
 {
     /**
      * @param string[] $filePaths
-     * @param mixed[] $expectedErrorsWithLines
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorsWithLines
      */
     #[DataProvider('provideData')]
     public function testRule(array $filePaths, array $expectedErrorsWithLines): void

--- a/tests/Rules/ParamTypeCoverageRule/ParamTypeCoverageRuleTest.php
+++ b/tests/Rules/ParamTypeCoverageRule/ParamTypeCoverageRuleTest.php
@@ -16,7 +16,7 @@ final class ParamTypeCoverageRuleTest extends RuleTestCase
 {
     /**
      * @param string[] $filePaths
-     * @param mixed[] $expectedErrorsWithLines
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorsWithLines
      */
     #[DataProvider('provideData')]
     public function testRule(array $filePaths, array $expectedErrorsWithLines): void

--- a/tests/Rules/PropertyTypeCoverageRule/PropertyTypeCoverageRuleTest.php
+++ b/tests/Rules/PropertyTypeCoverageRule/PropertyTypeCoverageRuleTest.php
@@ -16,7 +16,7 @@ final class PropertyTypeCoverageRuleTest extends RuleTestCase
 {
     /**
      * @param string[] $filePaths
-     * @param mixed[] $expectedErrorsWithLines
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorsWithLines
      */
     #[DataProvider('provideData')]
     public function testRule(array $filePaths, array $expectedErrorsWithLines): void

--- a/tests/Rules/ReturnTypeCoverageRule/ReturnTypeCoverageRuleTest.php
+++ b/tests/Rules/ReturnTypeCoverageRule/ReturnTypeCoverageRuleTest.php
@@ -16,7 +16,7 @@ final class ReturnTypeCoverageRuleTest extends RuleTestCase
 {
     /**
      * @param string[] $filePaths
-     * @param mixed[] $expectedErrorsWithLines
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorsWithLines
      */
     #[DataProvider('provideData')]
     public function testRule(array $filePaths, array $expectedErrorsWithLines): void


### PR DESCRIPTION
Updates code to be compatible with PHPStan 2.0

Had to remove `rector/rector` and `tomasvotruba/unused-public` to install it to run the tests, will need to be updated once these dependencies are compatible with phpstan 2.0