### PR TITLE
Add error identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor
 composer.lock
 
+.idea
 /.phpunit.cache

--- a/src/Formatter/TypeCoverageFormatter.php
+++ b/src/Formatter/TypeCoverageFormatter.php
@@ -15,6 +15,7 @@ final class TypeCoverageFormatter
      */
     public function formatErrors(
         string $message,
+        string $identifier,
         float|int $minimalLevel,
         TypeCountAndMissingTypes $typeCountAndMissingTypes
     ): array {
@@ -42,6 +43,7 @@ final class TypeCoverageFormatter
 
             foreach ($lines as $line) {
                 $ruleErrors[] = RuleErrorBuilder::message($errorMessage)
+                    ->identifier($identifier)
                     ->file($filePath)
                     ->line($line)
                     ->build();

--- a/src/Rules/ConstantTypeCoverageRule.php
+++ b/src/Rules/ConstantTypeCoverageRule.php
@@ -25,6 +25,11 @@ final readonly class ConstantTypeCoverageRule implements Rule
      */
     public const ERROR_MESSAGE = 'Out of %d possible constant types, only %d - %.1f %% actually have it. Add more constant types to get over %s %%';
 
+    /**
+     * @var string
+     */
+    private const IDENTIFIER = 'typeCoverage.constantTypeCoverage';
+
     public function __construct(
         private TypeCoverageFormatter $typeCoverageFormatter,
         private Configuration $configuration,
@@ -65,6 +70,7 @@ final readonly class ConstantTypeCoverageRule implements Rule
 
         return $this->typeCoverageFormatter->formatErrors(
             self::ERROR_MESSAGE,
+            self::IDENTIFIER,
             $this->configuration->getRequiredConstantTypeLevel(),
             $typeCountAndMissingTypes
         );

--- a/src/Rules/ParamTypeCoverageRule.php
+++ b/src/Rules/ParamTypeCoverageRule.php
@@ -25,6 +25,11 @@ final readonly class ParamTypeCoverageRule implements Rule
      */
     public const ERROR_MESSAGE = 'Out of %d possible param types, only %d - %.1f %% actually have it. Add more param types to get over %s %%';
 
+    /**
+     * @var string
+     */
+    private const IDENTIFIER = 'typeCoverage.paramTypeCoverage';
+
     public function __construct(
         private TypeCoverageFormatter $typeCoverageFormatter,
         private Configuration $configuration,
@@ -66,6 +71,7 @@ final readonly class ParamTypeCoverageRule implements Rule
 
         return $this->typeCoverageFormatter->formatErrors(
             self::ERROR_MESSAGE,
+            self::IDENTIFIER,
             $this->configuration->getRequiredParamTypeLevel(),
             $typeCountAndMissingTypes
         );

--- a/src/Rules/PropertyTypeCoverageRule.php
+++ b/src/Rules/PropertyTypeCoverageRule.php
@@ -25,6 +25,11 @@ final readonly class PropertyTypeCoverageRule implements Rule
      */
     public const ERROR_MESSAGE = 'Out of %d possible property types, only %d - %.1f %% actually have it. Add more property types to get over %s %%';
 
+    /**
+     * @var string
+     */
+    private const IDENTIFIER = 'typeCoverage.propertyTypeCoverage';
+
     public function __construct(
         private TypeCoverageFormatter $typeCoverageFormatter,
         private Configuration $configuration,
@@ -65,6 +70,7 @@ final readonly class PropertyTypeCoverageRule implements Rule
 
         return $this->typeCoverageFormatter->formatErrors(
             self::ERROR_MESSAGE,
+            self::IDENTIFIER,
             $this->configuration->getRequiredPropertyTypeLevel(),
             $typeCountAndMissingTypes
         );

--- a/src/Rules/ReturnTypeCoverageRule.php
+++ b/src/Rules/ReturnTypeCoverageRule.php
@@ -25,6 +25,11 @@ final readonly class ReturnTypeCoverageRule implements Rule
      */
     public const ERROR_MESSAGE = 'Out of %d possible return types, only %d - %.1f %% actually have it. Add more return types to get over %s %%';
 
+    /**
+     * @var string
+     */
+    private const IDENTIFIER = 'typeCoverage.returnTypeCoverage';
+
     public function __construct(
         private TypeCoverageFormatter $typeCoverageFormatter,
         private Configuration $configuration,
@@ -65,6 +70,7 @@ final readonly class ReturnTypeCoverageRule implements Rule
 
         return $this->typeCoverageFormatter->formatErrors(
             self::ERROR_MESSAGE,
+            self::IDENTIFIER,
             $this->configuration->getRequiredReturnTypeLevel(),
             $typeCountAndMissingTypes
         );


### PR DESCRIPTION
Similar to https://github.com/rectorphp/type-perfect/pull/43

This will allow ignoring the errors from this package without ignoring other PHPStan errors.

My use case is overriding a parent property without types, which I'm not allowed to type because of the parent definition.