### PR TITLE
Add allow_partial_paths option to enable type coverage on subpaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,20 @@ That's why this package only triggers if there are full paths, e.g.:
 
 ```bash
 vendor/bin/phpstan
-````
+```
+
+### Allowing Partial Path Analysis
+
+If you want to enable type coverage analysis even when running on specific subpaths, you can use the `allow_partial_paths` option:
+
+```yaml
+# phpstan.neon
+parameters:
+    type_coverage:
+        allow_partial_paths: true
+```
+
+**Warning:** When `allow_partial_paths` is enabled, the coverage percentages may not represent the actual coverage of your entire codebase, as they will only reflect the analyzed subset of files. Use this option carefully and consider the potential for misleading results.
 
 <br>
 

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -14,6 +14,9 @@ parametersSchema:
         property: anyOf(schema(float(), nullable()), schema(int(), nullable()))
         constant: anyOf(schema(float(), nullable()), schema(int(), nullable()))
 
+        # path validation
+        allow_partial_paths: bool()
+        
         # measure
         measure: bool()
     ])
@@ -34,6 +37,9 @@ parameters:
         param: null
         property: null
         constant: null
+
+        # path validation (disabled by default to keep existing behavior)
+        allow_partial_paths: false
 
         measure: false
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -48,6 +48,11 @@ final readonly class Configuration
         return $this->parameters['declare'];
     }
 
+    public function allowPartialPaths(): bool
+    {
+        return $this->parameters['allow_partial_paths'];
+    }
+
     public function showOnlyMeasure(): bool
     {
         return $this->parameters['measure'];

--- a/src/Configuration/ScopeConfigurationResolver.php
+++ b/src/Configuration/ScopeConfigurationResolver.php
@@ -9,6 +9,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\MemoizingContainer;
 use PHPStan\DependencyInjection\Nette\NetteContainer;
 use ReflectionProperty;
+use TomasVotruba\TypeCoverage\Configuration;
 
 /**
  * The easiest way to reach project configuration from Scope object
@@ -17,7 +18,7 @@ final class ScopeConfigurationResolver
 {
     private static ?bool $areFullPathsAnalysed = null;
 
-    public static function areFullPathsAnalysed(Scope $scope): bool
+    private static function areFullPathsAnalysed(Scope $scope): bool
     {
         // cache for speed
         if (self::$areFullPathsAnalysed !== null) {
@@ -46,6 +47,17 @@ final class ScopeConfigurationResolver
         self::$areFullPathsAnalysed = $analysedPathsFromConfig === $analysedPaths;
 
         return self::$areFullPathsAnalysed;
+    }
+
+    public static function shouldSkipPartialPathsAnalysis(Scope $scope, Configuration $configuration): bool
+    {
+        // If allow_partial_paths is enabled, don't skip analysis even for partial paths
+        if ($configuration->allowPartialPaths()) {
+            return false;
+        }
+
+        // skip if not full paths
+        return ! self::areFullPathsAnalysed($scope);
     }
 
     private static function getPrivateProperty(object $object, string $propertyName): object

--- a/src/Rules/ConstantTypeCoverageRule.php
+++ b/src/Rules/ConstantTypeCoverageRule.php
@@ -55,7 +55,8 @@ final readonly class ConstantTypeCoverageRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         // if only subpaths are analysed, skip as data will be false positive
-        if (! ScopeConfigurationResolver::areFullPathsAnalysed($scope)) {
+        // can be overridden by allow_partial_paths option
+        if (ScopeConfigurationResolver::shouldSkipPartialPathsAnalysis($scope, $this->configuration)) {
             return [];
         }
 

--- a/src/Rules/DeclareCoverageRule.php
+++ b/src/Rules/DeclareCoverageRule.php
@@ -46,7 +46,8 @@ final readonly class DeclareCoverageRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         // if only subpaths are analysed, skip as data will be false positive
-        if (! ScopeConfigurationResolver::areFullPathsAnalysed($scope)) {
+        // can be overridden by allow_partial_paths option
+        if (ScopeConfigurationResolver::shouldSkipPartialPathsAnalysis($scope, $this->configuration)) {
             return [];
         }
 

--- a/src/Rules/ParamTypeCoverageRule.php
+++ b/src/Rules/ParamTypeCoverageRule.php
@@ -55,7 +55,8 @@ final readonly class ParamTypeCoverageRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         // if only subpaths are analysed, skip as data will be false positive
-        if (! ScopeConfigurationResolver::areFullPathsAnalysed($scope)) {
+        // can be overridden by allow_partial_paths option
+        if (ScopeConfigurationResolver::shouldSkipPartialPathsAnalysis($scope, $this->configuration)) {
             return [];
         }
 

--- a/src/Rules/PropertyTypeCoverageRule.php
+++ b/src/Rules/PropertyTypeCoverageRule.php
@@ -55,7 +55,8 @@ final readonly class PropertyTypeCoverageRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         // if only subpaths are analysed, skip as data will be false positive
-        if (! ScopeConfigurationResolver::areFullPathsAnalysed($scope)) {
+        // can be overridden by allow_partial_paths option
+        if (ScopeConfigurationResolver::shouldSkipPartialPathsAnalysis($scope, $this->configuration)) {
             return [];
         }
 

--- a/src/Rules/ReturnTypeCoverageRule.php
+++ b/src/Rules/ReturnTypeCoverageRule.php
@@ -55,7 +55,8 @@ final readonly class ReturnTypeCoverageRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         // if only subpaths are analysed, skip as data will be false positive
-        if (! ScopeConfigurationResolver::areFullPathsAnalysed($scope)) {
+        // can be overridden by allow_partial_paths option
+        if (ScopeConfigurationResolver::shouldSkipPartialPathsAnalysis($scope, $this->configuration)) {
             return [];
         }
 


### PR DESCRIPTION
## What

Adds a new `allow_partial_paths` configuration option that allows type coverage analysis to run even when analyzing only specific subpaths (e.g., `vendor/bin/phpstan analyze src/Controller`).

## Why

By default, type-coverage only triggers when full paths are analyzed to avoid false positives from incomplete data. However, there are cases where users want to check type coverage on specific subpaths despite potential inaccuracies.

## How

- Added `allow_partial_paths: bool` configuration option (defaults to `false`)
- Modified all coverage rules to respect this new option via `ScopeConfigurationResolver::shouldSkipPartialPathsAnalysis()`
- Updated documentation with usage examples and warnings

## Usage

```yaml
# phpstan.neon
parameters:
    type_coverage:
        return: 50
        param: 35.5
        property: 70
        
        allow_partial_paths: true  # Enable analysis on partial paths