### PR TITLE
fix: Missing Identifier for "DeclareCoverageRule"-Errors (fixes TomasVotruba/type-coverage#61)

### DIFF
--- a/src/Rules/DeclareCoverageRule.php
+++ b/src/Rules/DeclareCoverageRule.php
@@ -23,6 +23,8 @@ final readonly class DeclareCoverageRule implements Rule
 {
     public const string ERROR_MESSAGE = 'Out of %d possible declare(strict_types=1), only %d - %.1f %% actually have it. Add more declares to get over %s %%';
 
+    private const string IDENTIFIER = 'typeCoverage.declareCoverage';
+
     public function __construct(
         private Configuration $configuration,
     ) {
@@ -100,7 +102,10 @@ final readonly class DeclareCoverageRule implements Rule
                 $requiredDeclareLevel,
             );
 
-            $ruleErrors[] = RuleErrorBuilder::message($errorMessage)->file($notCoveredDeclareFilePath)->build();
+            $ruleErrors[] = RuleErrorBuilder::message($errorMessage)
+                ->identifier(self::IDENTIFIER)
+                ->file($notCoveredDeclareFilePath)
+                ->build();
         }
 
         return $ruleErrors;


### PR DESCRIPTION
## Summary
Fixes TomasVotruba/type-coverage#61 — Missing Identifier for "DeclareCoverageRule"-Errors

## Root cause
See the commit message and diff for details of what was changed and why.

## Testing
- Test suite was run locally — see commit for details.

> Opened automatically by bin/handyman.php. Please review carefully before merging.