### PR TITLE
fix: BUG: Type coverage when method override without typehint (fixes TomasVotruba/type-coverage#26)

### DIFF
--- a/src/Collectors/ParamTypeDeclarationCollector.php
+++ b/src/Collectors/ParamTypeDeclarationCollector.php
@@ -7,8 +7,10 @@ namespace TomasVotruba\TypeCoverage\Collectors;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
+use PHPStan\Reflection\ClassReflection;
 
 /**
  * @see \TomasVotruba\TypeCoverage\Rules\ParamTypeCoverageRule
@@ -33,16 +35,23 @@ final class ParamTypeDeclarationCollector implements Collector
         $missingTypeLines = [];
         $paramCount = count($node->getParams());
 
-        foreach ($node->getParams() as $param) {
+        foreach ($node->getParams() as $position => $param) {
             if ($param->variadic) {
                 // skip variadic
                 --$paramCount;
                 continue;
             }
 
-            if ($param->type === null) {
-                $missingTypeLines[] = $param->getLine();
+            if ($param->type !== null) {
+                continue;
             }
+
+            // parent method's param has no native type → LSP prevents adding one in child
+            if ($this->isParamGuardedByParentMethod($scope, $node, $position)) {
+                continue;
+            }
+
+            $missingTypeLines[] = $param->getLine();
         }
 
         return [$paramCount, $missingTypeLines];
@@ -68,5 +77,42 @@ final class ParamTypeDeclarationCollector implements Collector
 
         $docCommentText = $docComment->getText();
         return str_contains($docCommentText, '@param callable');
+    }
+
+    private function isParamGuardedByParentMethod(Scope $scope, FunctionLike $functionLike, int $position): bool
+    {
+        if (! $functionLike instanceof ClassMethod) {
+            return false;
+        }
+
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        $methodName = $functionLike->name->toString();
+
+        foreach ($classReflection->getParents() as $parentClassReflection) {
+            if (! $parentClassReflection->hasNativeMethod($methodName)) {
+                continue;
+            }
+
+            $variants = $parentClassReflection->getNativeMethod($methodName)
+                ->getVariants();
+            if ($variants === []) {
+                continue;
+            }
+
+            $parentParameters = $variants[0]->getParameters();
+            if (! isset($parentParameters[$position])) {
+                continue;
+            }
+
+            if (! $parentParameters[$position]->hasNativeType()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Collectors/ReturnTypeDeclarationCollector.php
+++ b/src/Collectors/ReturnTypeDeclarationCollector.php
@@ -8,6 +8,8 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\MixedType;
 
 /**
  * @see \TomasVotruba\TypeCoverage\Rules\ReturnTypeCoverageRule
@@ -39,10 +41,39 @@ final class ReturnTypeDeclarationCollector implements Collector
 
         $missingTypeLines = [];
 
-        if (! $node->returnType instanceof Node) {
+        if (! $node->returnType instanceof Node && ! $this->isReturnGuardedByParentMethod($scope, $node)) {
             $missingTypeLines[] = $node->getLine();
         }
 
         return [1, $missingTypeLines];
+    }
+
+    private function isReturnGuardedByParentMethod(Scope $scope, ClassMethod $classMethod): bool
+    {
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        $methodName = $classMethod->name->toString();
+
+        foreach ($classReflection->getParents() as $parentClassReflection) {
+            if (! $parentClassReflection->hasNativeMethod($methodName)) {
+                continue;
+            }
+
+            $variants = $parentClassReflection->getNativeMethod($methodName)
+                ->getVariants();
+            if ($variants === []) {
+                continue;
+            }
+
+            $nativeReturnType = $variants[0]->getNativeReturnType();
+            if ($nativeReturnType instanceof MixedType && ! $nativeReturnType->isExplicitMixed()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Rules/ParamTypeCoverageRule/Fixture/SkipParentBlockingParam.php
+++ b/tests/Rules/ParamTypeCoverageRule/Fixture/SkipParentBlockingParam.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\TypeCoverage\Tests\Rules\ParamTypeCoverageRule\Fixture;
+
+use TomasVotruba\TypeCoverage\Tests\Rules\ParamTypeCoverageRule\Source\ParentWithDocBlockOnlyParam;
+
+final class SkipParentBlockingParam extends ParentWithDocBlockOnlyParam
+{
+    public function run($name)
+    {
+    }
+}

--- a/tests/Rules/ParamTypeCoverageRule/ParamTypeCoverageRuleTest.php
+++ b/tests/Rules/ParamTypeCoverageRule/ParamTypeCoverageRuleTest.php
@@ -33,6 +33,7 @@ final class ParamTypeCoverageRuleTest extends RuleTestCase
         yield [[__DIR__ . '/Fixture/SkipKnownParamType.php', __DIR__ . '/Fixture/SkipAgainKnownParamType.php'], []];
         yield [[__DIR__ . '/Fixture/SkipVariadic.php'], []];
         yield [[__DIR__ . '/Fixture/SkipCallableParam.php'], []];
+        yield [[__DIR__ . '/Fixture/SkipParentBlockingParam.php'], []];
 
         $firstErrorMessage = sprintf(ParamTypeCoverageRule::ERROR_MESSAGE, 3, 1, 33.3, 80);
         $thirdErrorMessage = sprintf(ParamTypeCoverageRule::ERROR_MESSAGE, 3, 1, 33.3, 80);

--- a/tests/Rules/ParamTypeCoverageRule/Source/ParentWithDocBlockOnlyParam.php
+++ b/tests/Rules/ParamTypeCoverageRule/Source/ParentWithDocBlockOnlyParam.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\TypeCoverage\Tests\Rules\ParamTypeCoverageRule\Source;
+
+class ParentWithDocBlockOnlyParam
+{
+    /**
+     * @param string $name
+     */
+    public function run($name)
+    {
+    }
+}

--- a/tests/Rules/ReturnTypeCoverageRule/Fixture/SkipParentBlockingReturn.php
+++ b/tests/Rules/ReturnTypeCoverageRule/Fixture/SkipParentBlockingReturn.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\TypeCoverage\Tests\Rules\ReturnTypeCoverageRule\Fixture;
+
+use TomasVotruba\TypeCoverage\Tests\Rules\ReturnTypeCoverageRule\Source\ParentWithDocBlockOnlyReturn;
+
+final class SkipParentBlockingReturn extends ParentWithDocBlockOnlyReturn
+{
+    public function run()
+    {
+        return 'child value';
+    }
+}

--- a/tests/Rules/ReturnTypeCoverageRule/ReturnTypeCoverageRuleTest.php
+++ b/tests/Rules/ReturnTypeCoverageRule/ReturnTypeCoverageRuleTest.php
@@ -33,6 +33,7 @@ final class ReturnTypeCoverageRuleTest extends RuleTestCase
         yield [[__DIR__ . '/Fixture/SkipKnownReturnType.php', __DIR__ . '/Fixture/SkipAgainKnownReturnType.php'], []];
         yield [[__DIR__ . '/Fixture/SkipConstructor.php'], []];
         yield [[__DIR__ . '/Fixture/SkipTraitConstructor.php'], []];
+        yield [[__DIR__ . '/Fixture/SkipParentBlockingReturn.php'], []];
 
         $errorMessage = sprintf(ReturnTypeCoverageRule::ERROR_MESSAGE, 2, 0, 0, 80);
         yield [[__DIR__ . '/Fixture/UnknownReturnType.php'], [[$errorMessage, 9], [$errorMessage, 13]]];

--- a/tests/Rules/ReturnTypeCoverageRule/Source/ParentWithDocBlockOnlyReturn.php
+++ b/tests/Rules/ReturnTypeCoverageRule/Source/ParentWithDocBlockOnlyReturn.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\TypeCoverage\Tests\Rules\ReturnTypeCoverageRule\Source;
+
+class ParentWithDocBlockOnlyReturn
+{
+    /**
+     * @return string
+     */
+    public function run()
+    {
+        return 'value';
+    }
+}


### PR DESCRIPTION
## Summary
Fixes TomasVotruba/type-coverage#26 — BUG: Type coverage when method override without typehint

## Root cause
See the commit message and diff for details of what was changed and why.

## Testing
- Test suite was run locally — see commit for details.

> Opened automatically by bin/handyman.php. Please review carefully before merging.