### PR TITLE
fix: BUG: Type coverage when method override without typehint (fixes TomasVotruba/type-coverage#26)

### DIFF
--- a/src/Collectors/ParamTypeDeclarationCollector.php
+++ b/src/Collectors/ParamTypeDeclarationCollector.php
@@ -7,8 +7,10 @@ namespace TomasVotruba\TypeCoverage\Collectors;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
+use PHPStan\Reflection\ClassReflection;
 
 /**
  * @see \TomasVotruba\TypeCoverage\Rules\ParamTypeCoverageRule
@@ -27,6 +29,11 @@ final class ParamTypeDeclarationCollector implements Collector
     public function processNode(Node $node, Scope $scope): ?array
     {
         if ($this->shouldSkipFunctionLike($node)) {
+            return null;
+        }
+
+        // skip methods inherited from a parent class or interface, as types are locked by LSP
+        if ($node instanceof ClassMethod && $this->isGuardedByParentMethod($scope, $node)) {
             return null;
         }
 
@@ -56,6 +63,30 @@ final class ParamTypeDeclarationCollector implements Collector
         }
 
         return $this->hasFunctionLikeCallableParam($functionLike);
+    }
+
+    private function isGuardedByParentMethod(Scope $scope, ClassMethod $classMethod): bool
+    {
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        $methodName = $classMethod->name->toString();
+
+        foreach ($classReflection->getParents() as $parentClassReflection) {
+            if ($parentClassReflection->hasMethod($methodName)) {
+                return true;
+            }
+        }
+
+        foreach ($classReflection->getInterfaces() as $interfaceReflection) {
+            if ($interfaceReflection->hasMethod($methodName)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function hasFunctionLikeCallableParam(FunctionLike $functionLike): bool

--- a/src/Collectors/ReturnTypeDeclarationCollector.php
+++ b/src/Collectors/ReturnTypeDeclarationCollector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
+use PHPStan\Reflection\ClassReflection;
 
 /**
  * @see \TomasVotruba\TypeCoverage\Rules\ReturnTypeCoverageRule
@@ -37,6 +38,11 @@ final class ReturnTypeDeclarationCollector implements Collector
             }
         }
 
+        // skip methods inherited from a parent class or interface, as types are locked by LSP
+        if ($this->isGuardedByParentMethod($scope, $node)) {
+            return null;
+        }
+
         $missingTypeLines = [];
 
         if (! $node->returnType instanceof Node) {
@@ -44,5 +50,29 @@ final class ReturnTypeDeclarationCollector implements Collector
         }
 
         return [1, $missingTypeLines];
+    }
+
+    private function isGuardedByParentMethod(Scope $scope, ClassMethod $classMethod): bool
+    {
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        $methodName = $classMethod->name->toString();
+
+        foreach ($classReflection->getParents() as $parentClassReflection) {
+            if ($parentClassReflection->hasMethod($methodName)) {
+                return true;
+            }
+        }
+
+        foreach ($classReflection->getInterfaces() as $interfaceReflection) {
+            if ($interfaceReflection->hasMethod($methodName)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Rules/ParamTypeCoverageRule/Fixture/SkipParentMethodOverride.php
+++ b/tests/Rules/ParamTypeCoverageRule/Fixture/SkipParentMethodOverride.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\TypeCoverage\Tests\Rules\ParamTypeCoverageRule\Fixture;
+
+final class SkipParentMethodOverride extends SkipParentMethodOverrideParent
+{
+    /**
+     * @param string $name
+     */
+    public function run($name)
+    {
+    }
+}

--- a/tests/Rules/ParamTypeCoverageRule/Fixture/SkipParentMethodOverrideParent.php
+++ b/tests/Rules/ParamTypeCoverageRule/Fixture/SkipParentMethodOverrideParent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\TypeCoverage\Tests\Rules\ParamTypeCoverageRule\Fixture;
+
+abstract class SkipParentMethodOverrideParent
+{
+    /**
+     * @param string $name
+     */
+    public function run($name)
+    {
+    }
+}

--- a/tests/Rules/ParamTypeCoverageRule/ParamTypeCoverageRuleTest.php
+++ b/tests/Rules/ParamTypeCoverageRule/ParamTypeCoverageRuleTest.php
@@ -33,6 +33,7 @@ final class ParamTypeCoverageRuleTest extends RuleTestCase
         yield [[__DIR__ . '/Fixture/SkipKnownParamType.php', __DIR__ . '/Fixture/SkipAgainKnownParamType.php'], []];
         yield [[__DIR__ . '/Fixture/SkipVariadic.php'], []];
         yield [[__DIR__ . '/Fixture/SkipCallableParam.php'], []];
+        yield [[__DIR__ . '/Fixture/SkipParentMethodOverride.php'], []];
 
         $firstErrorMessage = sprintf(ParamTypeCoverageRule::ERROR_MESSAGE, 3, 1, 33.3, 80);
         $thirdErrorMessage = sprintf(ParamTypeCoverageRule::ERROR_MESSAGE, 3, 1, 33.3, 80);

--- a/tests/Rules/ReturnTypeCoverageRule/Fixture/SkipParentMethodOverride.php
+++ b/tests/Rules/ReturnTypeCoverageRule/Fixture/SkipParentMethodOverride.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\TypeCoverage\Tests\Rules\ReturnTypeCoverageRule\Fixture;
+
+final class SkipParentMethodOverride extends SkipParentMethodOverrideParent
+{
+    /**
+     * @return int
+     */
+    public function run()
+    {
+        return 2;
+    }
+}

--- a/tests/Rules/ReturnTypeCoverageRule/Fixture/SkipParentMethodOverrideParent.php
+++ b/tests/Rules/ReturnTypeCoverageRule/Fixture/SkipParentMethodOverrideParent.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\TypeCoverage\Tests\Rules\ReturnTypeCoverageRule\Fixture;
+
+abstract class SkipParentMethodOverrideParent
+{
+    /**
+     * @return int
+     */
+    public function run()
+    {
+        return 1;
+    }
+}

--- a/tests/Rules/ReturnTypeCoverageRule/ReturnTypeCoverageRuleTest.php
+++ b/tests/Rules/ReturnTypeCoverageRule/ReturnTypeCoverageRuleTest.php
@@ -33,6 +33,7 @@ final class ReturnTypeCoverageRuleTest extends RuleTestCase
         yield [[__DIR__ . '/Fixture/SkipKnownReturnType.php', __DIR__ . '/Fixture/SkipAgainKnownReturnType.php'], []];
         yield [[__DIR__ . '/Fixture/SkipConstructor.php'], []];
         yield [[__DIR__ . '/Fixture/SkipTraitConstructor.php'], []];
+        yield [[__DIR__ . '/Fixture/SkipParentMethodOverride.php'], []];
 
         $errorMessage = sprintf(ReturnTypeCoverageRule::ERROR_MESSAGE, 2, 0, 0, 80);
         yield [[__DIR__ . '/Fixture/UnknownReturnType.php'], [[$errorMessage, 9], [$errorMessage, 13]]];


### PR DESCRIPTION
## Summary
Fixes TomasVotruba/type-coverage#26 — BUG: Type coverage when method override without typehint

## Root cause
See the commit message and diff for details of what was changed and why.

## Testing
- Test suite was run locally — see commit for details.

> Opened automatically by bin/handyman.php. Please review carefully before merging.