### PR TITLE
fix: Does not report error from used trait correctly (fixes TomasVotruba/type-coverage#32)

### DIFF
--- a/src/CollectorDataNormalizer.php
+++ b/src/CollectorDataNormalizer.php
@@ -9,7 +9,7 @@ use TomasVotruba\TypeCoverage\ValueObject\TypeCountAndMissingTypes;
 final class CollectorDataNormalizer
 {
     /**
-     * @param array<string, array<array{0: int, 1: array<string, int>}>> $collectorDataByPath
+     * @param array<string, array<array{0: int, 1: array<int, int>, 2?: string|null}>> $collectorDataByPath
      */
     public function normalize(array $collectorDataByPath): TypeCountAndMissingTypes
     {
@@ -24,8 +24,12 @@ final class CollectorDataNormalizer
 
                 $missingCount += count($nestedData[1]);
 
-                $missingTypeLinesByFilePath[$filePath] = array_merge(
-                    $missingTypeLinesByFilePath[$filePath] ?? [],
+                // if the node is from a trait, route the error to the trait file
+                // instead of the using-class file, so lines match the actual source
+                $effectiveFilePath = $nestedData[2] ?? $filePath;
+
+                $missingTypeLinesByFilePath[$effectiveFilePath] = array_merge(
+                    $missingTypeLinesByFilePath[$effectiveFilePath] ?? [],
                     $nestedData[1]
                 );
             }

--- a/src/Collectors/ConstantTypeDeclarationCollector.php
+++ b/src/Collectors/ConstantTypeDeclarationCollector.php
@@ -26,13 +26,13 @@ final class ConstantTypeDeclarationCollector implements Collector
 
     /**
      * @param ClassConstantsNode $node
-     * @return array<int, int|list<(int | int<1, max>)>>
+     * @return array{int, list<int>, string|null}
      */
     public function processNode(Node $node, Scope $scope): array
     {
         // enable only on PHP 8.3+
         if (PHP_VERSION_ID < 80300) {
-            return [0, []];
+            return [0, [], null];
         }
 
         $constantCount = count($node->getConstants());
@@ -54,7 +54,13 @@ final class ConstantTypeDeclarationCollector implements Collector
             $missingTypeLines[] = $classConst->getLine();
         }
 
-        return [$constantCount, $missingTypeLines];
+        $traitFilePath = null;
+        if ($scope->isInTrait()) {
+            $traitFilePath = $scope->getTraitReflection()
+                ->getFileName();
+        }
+
+        return [$constantCount, $missingTypeLines, $traitFilePath];
     }
 
     private function isGuardedByParentClassConstant(Scope $scope, ClassConst $classConst): bool

--- a/src/Collectors/ParamTypeDeclarationCollector.php
+++ b/src/Collectors/ParamTypeDeclarationCollector.php
@@ -24,7 +24,7 @@ final class ParamTypeDeclarationCollector implements Collector
 
     /**
      * @param FunctionLike $node
-     * @return mixed[]|null
+     * @return array{int, list<int>, string|null}|null
      */
     public function processNode(Node $node, Scope $scope): ?array
     {
@@ -52,7 +52,17 @@ final class ParamTypeDeclarationCollector implements Collector
             }
         }
 
-        return [$paramCount, $missingTypeLines];
+        return [$paramCount, $missingTypeLines, $this->resolveTraitFilePath($scope)];
+    }
+
+    private function resolveTraitFilePath(Scope $scope): ?string
+    {
+        if (! $scope->isInTrait()) {
+            return null;
+        }
+
+        return $scope->getTraitReflection()
+            ->getFileName();
     }
 
     private function shouldSkipFunctionLike(FunctionLike $functionLike): bool

--- a/src/Collectors/PropertyTypeDeclarationCollector.php
+++ b/src/Collectors/PropertyTypeDeclarationCollector.php
@@ -27,7 +27,7 @@ final class PropertyTypeDeclarationCollector implements Collector
 
     /**
      * @param InClassNode $node
-     * @return array<int, int|list<(int | int<1, max>)>>
+     * @return array{int, list<int>, string|null}
      */
     public function processNode(Node $node, Scope $scope): array
     {
@@ -57,7 +57,13 @@ final class PropertyTypeDeclarationCollector implements Collector
             $missingTypeLines[] = $property->getLine();
         }
 
-        return [$propertyCount, $missingTypeLines];
+        $traitFilePath = null;
+        if ($scope->isInTrait()) {
+            $traitFilePath = $scope->getTraitReflection()
+                ->getFileName();
+        }
+
+        return [$propertyCount, $missingTypeLines, $traitFilePath];
     }
 
     private function isPropertyDocTyped(Property $property): bool

--- a/src/Collectors/ReturnTypeDeclarationCollector.php
+++ b/src/Collectors/ReturnTypeDeclarationCollector.php
@@ -21,7 +21,7 @@ final class ReturnTypeDeclarationCollector implements Collector
 
     /**
      * @param ClassMethod $node
-     * @return mixed[]|null
+     * @return array{int, list<int>, string|null}|null
      */
     public function processNode(Node $node, Scope $scope): ?array
     {
@@ -30,11 +30,15 @@ final class ReturnTypeDeclarationCollector implements Collector
             return null;
         }
 
+        $traitFilePath = null;
         if ($scope->isInTrait()) {
             $originalMethodName = $node->getAttribute('originalTraitMethodName');
             if ($originalMethodName === '__construct') {
                 return null;
             }
+
+            $traitFilePath = $scope->getTraitReflection()
+                ->getFileName();
         }
 
         $missingTypeLines = [];
@@ -43,6 +47,6 @@ final class ReturnTypeDeclarationCollector implements Collector
             $missingTypeLines[] = $node->getLine();
         }
 
-        return [1, $missingTypeLines];
+        return [1, $missingTypeLines, $traitFilePath];
     }
 }

--- a/tests/Rules/ParamTypeCoverageRule/Fixture/ClassUsingTrait.php
+++ b/tests/Rules/ParamTypeCoverageRule/Fixture/ClassUsingTrait.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\TypeCoverage\Tests\Rules\ParamTypeCoverageRule\Fixture;
+
+use TomasVotruba\TypeCoverage\Tests\Rules\ParamTypeCoverageRule\Source\TraitWithMissingParamType;
+
+final class ClassUsingTrait
+{
+    use TraitWithMissingParamType;
+}

--- a/tests/Rules/ParamTypeCoverageRule/ParamTypeCoverageRuleTest.php
+++ b/tests/Rules/ParamTypeCoverageRule/ParamTypeCoverageRuleTest.php
@@ -41,6 +41,20 @@ final class ParamTypeCoverageRuleTest extends RuleTestCase
         yield [[__DIR__ . '/Fixture/UnknownParamType.php'], [[$firstErrorMessage, 9], [$thirdErrorMessage, 13]]];
     }
 
+    public function testErrorInTraitIsReportedAtTraitFile(): void
+    {
+        $classFile = __DIR__ . '/Fixture/ClassUsingTrait.php';
+        $traitFile = __DIR__ . '/Source/TraitWithMissingParamType.php';
+
+        $errors = $this->gatherAnalyserErrors([$classFile, $traitFile]);
+
+        $this->assertCount(1, $errors);
+
+        $error = $errors[0];
+        $this->assertSame($traitFile, $error->getFile());
+        $this->assertSame(9, $error->getLine());
+    }
+
     /**
      * @return string[]
      */

--- a/tests/Rules/ParamTypeCoverageRule/Source/TraitWithMissingParamType.php
+++ b/tests/Rules/ParamTypeCoverageRule/Source/TraitWithMissingParamType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\TypeCoverage\Tests\Rules\ParamTypeCoverageRule\Source;
+
+trait TraitWithMissingParamType
+{
+    public function traitMethod($value): void
+    {
+    }
+}


### PR DESCRIPTION
## Summary
Fixes TomasVotruba/type-coverage#32 — Does not report error from used trait correctly

## Root cause
See the commit message and diff for details of what was changed and why.

## Testing
- Test suite was run locally — see commit for details.

> Opened automatically by bin/handyman.php. Please review carefully before merging.