### PR TITLE
Merge rector/type-perfect into this repo

### DIFF
--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -14,7 +14,7 @@ jobs:
                 uses: actions/checkout@v3
                 with:
                     # Must be used to trigger workflow after push
-                    token: ${{ secrets.ACCESS_TOKEN }}
+                    token: ${{ secrets.WORKFLOWS_TOKEN || github.token }}
 
             -
                 uses: shivammathur/setup-php@v2

--- a/README.md
+++ b/README.md
@@ -138,3 +138,391 @@ vendor/bin/phpstan
 <br>
 
 Happy coding!
+
+<br>
+
+---
+
+# Type Perfect
+
+[![Downloads](https://img.shields.io/packagist/dt/rector/type-perfect.svg?style=flat-square)](https://packagist.org/packages/rector/type-perfect/stats)
+
+Next level type declaration check PHPStan rules.
+
+We use these sets to improve code quality of our clients' code beyond PHPStan features.
+
+* These rules make skipped object types explicit, param types narrow and help you to fill more accurate object type hints.
+* **They're easy to enable, even if your code does not pass level 0**
+* They're effortless to resolve and make your code instantly more solid and reliable.
+
+If you care about code quality and type safety, add these 10 rules to your CI.
+
+<br>
+
+## Install
+
+```bash
+composer require rector/type-perfect --dev
+```
+
+*Note: Make sure you use [`phpstan/extension-installer`](https://github.com/phpstan/extension-installer#usage) to load the necessary service configs or include `vendor/rector/type-perfect/config/extension.neon` file.*
+
+<br>
+
+There are 3 checks enabled out of the box. First one makes sure we don't miss a chance to use `instanceof` to make further code know about exact object type:
+
+```php
+private ?SomeType $someType = null;
+
+if (! empty($this->someType)) {
+    // ...
+}
+
+if (! isset($this->someType)) {
+    // ...
+}
+
+// here we only know, that $this->someType is not empty/null
+```
+
+:no_good:
+
+↓
+
+
+```php
+if (! $this->someType instanceof SomeType) {
+    return;
+}
+
+// here we know $this->someType is exactly SomeType
+```
+
+:heavy_check_mark:
+
+<br>
+
+Second rule checks we use explicit object methods over magic array access:
+
+```php
+$article = new Article();
+
+$id = $article['id'];
+// we have no idea, what the type is
+```
+
+:no_good:
+
+↓
+
+```php
+$id = $article->getId();
+// we know the type is int
+```
+
+:heavy_check_mark:
+
+<br>
+
+Last rule checks that all interface implementations follow the same method signature as the interface:
+
+```php
+interface SomeInterface
+{
+    public function doSomething(int $value): void;
+}
+
+final class SomeClass implements SomeInterface
+{
+     public function doSomething($value): void { // ... }
+}
+```
+
+:no_good:
+
+↓
+
+```php
+final class SomeClass implements SomeInterface
+{
+     public function doSomething(int $value): void { // ... }
+}
+```
+
+:heavy_check_mark:
+
+<br>
+
+## Configure
+
+Next rules you can enable by configuration. We take them from the simplest to more powerful, in the same order we apply them on legacy projects.
+
+You can enable them all at once:
+
+```yaml
+parameters:
+    type_perfect:
+        no_mixed_property: true
+        no_mixed_caller: true
+        null_over_false: true
+        narrow_param: true
+        narrow_return: true
+```
+
+Or one by one:
+
+<br>
+
+## 1. Null over False
+
+```yaml
+parameters:
+    type_perfect:
+        null_over_false: true
+```
+
+Bool types are typically used for on/off, yes/no responses. But sometimes, the `false` is misused as *no-result* response, where `null` would be more accurate:
+
+```php
+public function getProduct()
+{
+    if (...) {
+        return $product;
+    }
+
+    return false;
+}
+```
+
+:no_good:
+
+↓
+
+We should use `null` instead, as it enabled strict type declaration in form of `?Product` since PHP 7.1:
+
+```php
+public function getProduct(): ?Product
+{
+    if (...) {
+        return $product;
+    }
+
+    return null;
+}
+```
+
+:heavy_check_mark:
+
+<br>
+
+## 2. No mixed Property
+
+```yaml
+parameters:
+    type_perfect:
+        no_mixed_property: true
+```
+
+This rule focuses on PHPStan blind spot while fetching a property. If we have a property with unknown type, PHPStan is not be able to analyse it. It silently ignores it.
+
+```php
+private $someType;
+
+public function run()
+{
+    $this->someType->vale;
+}
+```
+
+It doesn't see there is a typo in `vale` property name. It should be `value`
+
+:no_good:
+
+↓
+
+
+```php
+private SomeType $someType;
+
+public function run()
+{
+    $this->someType->value;
+}
+```
+
+This rule makes sure all property fetches know their type they're called on.
+
+:heavy_check_mark:
+
+<br>
+
+## 3. No mixed Caller
+
+```yaml
+parameters:
+    type_perfect:
+        no_mixed_caller: true
+```
+
+Same as above, only for method calls:
+
+```php
+private $someType;
+
+public function run()
+{
+    $this->someType->someMetho(1, 2);
+}
+```
+
+It doesn't see there is a typo in `someMetho` name, and that the 2nd parameter must be `string`.
+
+:no_good:
+
+↓
+
+
+```php
+private SomeType $someType;
+
+public function run()
+{
+    $this->someType->someMethod(1, 'active');
+}
+```
+
+This group makes sure methods call know their type they're called on.
+
+:heavy_check_mark:
+
+<br>
+
+## 4. Narrow Param Types
+
+The more narrow param type we have, the reliable the code is. `string` beats `mixed`, `int` beats `scalar` and `ExactObject` beats `stdClass`.
+
+```yaml
+parameters:
+    type_perfect:
+        narrow_param: true
+```
+
+In case of `private`, but also `public` method calls, our project often knows exact types that are passed in it:
+
+```php
+// in one file
+$product->addPrice(100.52);
+
+// another file
+$product->addPrice(52.05);
+```
+
+But out of from fear and "just to be safe", we keep the `addPrice()` param type empty, `mixed` or in a docblock.
+
+:no_good:
+
+↓
+
+If, in 100 % cases the `float` type is passed, PHPStan knows it can be added and improve further analysis:
+
+```diff
+
+-/**
+- * @param float $price
+- */
+-public function addPrice($price)
++public function addPrice(float $price)
+{
+    $this->price = $price;
+}
+```
+
+That's where this group comes in. It checks all the passed types, and tells us know how to narrow the param type declaration.
+
+:heavy_check_mark:
+
+<br>
+
+## 5. Narrow Return Types
+
+Last but not least, the more narrow return type, the more reliable the code.
+
+```yaml
+parameters:
+    type_perfect:
+        narrow_return: true
+```
+
+Where does it help? Let's say we have 2 types of talks, that do have different behavior:
+
+```php
+final class ConferenceTalk extends Talk
+{
+    public function bookHotel()
+    {
+        // ...
+    }
+}
+
+final class MeetupTalk extends Talk
+{
+    public function bookTrain()
+    {
+        // ...
+    }
+}
+```
+
+Then we have a factory (repository, or services) that returns generic `Talk` type:
+
+```php
+final class TalkFactory
+{
+    public function createConferenceTalk(): Talk
+    {
+        return new ConferenceTalk();
+    }
+
+    public function createMeetupTalk(): Talk
+    {
+        return new MeetupTalk();
+    }
+}
+```
+
+In this case we've just lost strict type and have to verify the type on runtime:
+
+```php
+$talk instanceof ConferenceTalk
+```
+
+:no_good:
+
+↓
+
+That's where this group comes in. In case we return the exact type, we should use exact type in return type declaration to keep the code as reliable as possible:
+
+```diff
+ final class TalkFactory
+ {
+-    public function createConferenceTalk(): Talk
++    public function createConferenceTalk(): ConferenceTalk
+     {
+         return new ConferenceTalk();
+     }
+
+-    public function createMeetupTalk(): Talk
++    public function createMeetupTalk(): MeetupTalk
+     {
+         return new MeetupTalk();
+     }
+}
+```
+
+:heavy_check_mark:
+
+Add sets one by one, fix what you find helpful and ignore the rest.
+
+<br>
+
+Happy coding!

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -7,4 +7,9 @@ use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 
 return new Configuration()
     // PhpParser classes are provided by phpstan/phpstan, no need to require nikic/php-parser directly
-    ->ignoreErrorsOnPackage('nikic/php-parser', [ErrorType::SHADOW_DEPENDENCY]);
+    ->ignoreErrorsOnPackage('nikic/php-parser', [ErrorType::SHADOW_DEPENDENCY])
+    // type-perfect test fixtures are static analysis inputs, not real code, and reference 3rd-party classes on purpose
+    ->ignoreErrorsOnPath(
+        __DIR__ . '/packages/type-perfect/tests',
+        [ErrorType::UNKNOWN_CLASS, ErrorType::SHADOW_DEPENDENCY]
+    );

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     },
     "require-dev": {
         "phpstan/extension-installer": "^1.4",
-        "phpunit/phpunit": "^12.5",
-        "symplify/easy-coding-standard": "^13.1",
-        "rector/rector": "^2.4",
+        "phpunit/phpunit": "^13.2",
+        "symplify/easy-coding-standard": "^13.2",
+        "rector/rector": "^2.5",
         "tracy/tracy": "^2.12",
         "tomasvotruba/unused-public": "^2.2",
         "rector/jack": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "tracy/tracy": "^2.12",
         "tomasvotruba/unused-public": "^2.2",
         "rector/jack": "^1.0",
-        "shipmonk/composer-dependency-analyser": "^1.8"
+        "shipmonk/composer-dependency-analyser": "^1.8",
+        "symfony/dom-crawler": "^7.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "keywords": ["static analysis", "phpstan-extension"],
     "require": {
         "php": "^8.4",
-        "phpstan/phpstan": "^2.2"
+        "phpstan/phpstan": "^2.2",
+        "webmozart/assert": "^1.11 || ^2.1"
     },
     "require-dev": {
         "phpstan/extension-installer": "^1.4",
@@ -20,12 +21,14 @@
     },
     "autoload": {
         "psr-4": {
-            "TomasVotruba\\TypeCoverage\\": "src"
+            "TomasVotruba\\TypeCoverage\\": "src",
+            "Rector\\TypePerfect\\": "packages/type-perfect/src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "TomasVotruba\\TypeCoverage\\Tests\\": "tests"
+            "TomasVotruba\\TypeCoverage\\Tests\\": "tests",
+            "Rector\\TypePerfect\\Tests\\": "packages/type-perfect/tests"
         }
     },
     "scripts": {
@@ -43,7 +46,8 @@
     "extra": {
         "phpstan": {
             "includes": [
-                "config/extension.neon"
+                "config/extension.neon",
+                "packages/type-perfect/config/extension.neon"
             ]
         }
     }

--- a/packages/type-perfect/LICENSE
+++ b/packages/type-perfect/LICENSE
@@ -1,0 +1,25 @@
+The MIT License
+---------------
+
+Copyright (c) 2020 Tomas Votruba (https://tomasvotruba.com)
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/type-perfect/config/extension.neon
+++ b/packages/type-perfect/config/extension.neon
@@ -1,0 +1,78 @@
+parametersSchema:
+    # see https://doc.nette.org/en/schema for configuration
+    type_perfect: structure([
+        narrow_param: bool()
+        narrow_return: bool()
+        no_mixed: bool()
+        null_over_false: bool()
+
+        # replace for no_mixed
+        no_mixed_property: bool()
+        no_mixed_caller: bool()
+    ])
+
+# defaults
+parameters:
+    type_perfect:
+        narrow_param: false
+        narrow_return: false
+        no_mixed: false
+        null_over_false: false
+        # priority override of no_mixed
+        no_mixed_property: false
+        no_mixed_caller: false
+
+rules:
+    # enabled by default
+    - Rector\TypePerfect\Rules\NoParamTypeRemovalRule
+    - Rector\TypePerfect\Rules\NoArrayAccessOnObjectRule
+    - Rector\TypePerfect\Rules\NoIssetOnObjectRule
+    - Rector\TypePerfect\Rules\NoEmptyOnObjectRule
+
+    # turn on by the group name
+
+    # narrow_param
+    - Rector\TypePerfect\Rules\NarrowPublicClassMethodParamTypeRule
+    - Rector\TypePerfect\Rules\NarrowPrivateClassMethodParamTypeRule
+
+    # narrow_return
+    - Rector\TypePerfect\Rules\NarrowReturnObjectTypeRule
+
+    # no_mixed
+    - Rector\TypePerfect\Rules\NoMixedPropertyFetcherRule
+    - Rector\TypePerfect\Rules\NoMixedMethodCallerRule
+
+    # null_over_false
+    - Rector\TypePerfect\Rules\ReturnNullOverFalseRule
+
+services:
+    -
+        factory: Rector\TypePerfect\Configuration
+        arguments:
+            - %type_perfect%
+
+    - Rector\TypePerfect\NodeFinder\ClassMethodNodeFinder
+    - Rector\TypePerfect\NodeFinder\MethodCallNodeFinder
+    - Rector\TypePerfect\NodeFinder\ReturnNodeFinder
+    - Rector\TypePerfect\PhpDoc\ApiDocStmtAnalyzer
+    - Rector\TypePerfect\Printer\NodeComparator
+    - Rector\TypePerfect\Reflection\ReflectionParser
+    - Rector\TypePerfect\Reflection\MethodNodeAnalyser
+    - Rector\TypePerfect\Matcher\Collector\PublicClassMethodMatcher
+    - Rector\TypePerfect\Matcher\ClassMethodCallReferenceResolver
+    - Rector\TypePerfect\Printer\CollectorMetadataPrinter
+    - Rector\TypePerfect\Guard\EmptyIssetGuard
+
+    # for NarrowPublicClassMethodParamTypeByCallerTypeRule
+    -
+        class: Rector\TypePerfect\Collector\ClassMethod\PublicClassMethodParamTypesCollector
+        tags: [phpstan.collector]
+
+    -
+        class: Rector\TypePerfect\Collector\MethodCall\MethodCallArgTypesCollector
+        tags: [phpstan.collector]
+
+    -
+        class: Rector\TypePerfect\Collector\MethodCallableNode\MethodCallableCollector
+        tags:
+            - phpstan.collector

--- a/packages/type-perfect/src/Collector/ClassMethod/PublicClassMethodParamTypesCollector.php
+++ b/packages/type-perfect/src/Collector/ClassMethod/PublicClassMethodParamTypesCollector.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Collector\ClassMethod;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+use PHPStan\Reflection\ClassReflection;
+use Rector\TypePerfect\Configuration;
+use Rector\TypePerfect\Matcher\Collector\PublicClassMethodMatcher;
+use Rector\TypePerfect\PhpDoc\ApiDocStmtAnalyzer;
+use Rector\TypePerfect\Printer\CollectorMetadataPrinter;
+
+/**
+ * @implements Collector<ClassMethod, array{class-string, string, string, int}>
+ */
+final readonly class PublicClassMethodParamTypesCollector implements Collector
+{
+    public function __construct(
+        private ApiDocStmtAnalyzer $apiDocStmtAnalyzer,
+        private PublicClassMethodMatcher $publicClassMethodMatcher,
+        private CollectorMetadataPrinter $collectorMetadataPrinter,
+        private Configuration $configuration
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @param ClassMethod $node
+     * @return array{class-string, string, string, int}|null
+     */
+    public function processNode(Node $node, Scope $scope): ?array
+    {
+        if (! $this->configuration->isNarrowParamEnabled()) {
+            return null;
+        }
+
+        if ($node->params === []) {
+            return null;
+        }
+
+        if ($this->publicClassMethodMatcher->shouldSkipClassMethod($node)) {
+            return null;
+        }
+
+        // only if the class has no parents/implementers, to avoid class method required by contracts
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return null;
+        }
+
+        if ($this->apiDocStmtAnalyzer->hasApiDoc($node, $classReflection)) {
+            return null;
+        }
+
+        if ($this->publicClassMethodMatcher->shouldSkipClassReflection($classReflection)) {
+            return null;
+        }
+
+        $methodName = $node->name->toString();
+
+        // is this method required by parent contract? skip it
+        if ($this->publicClassMethodMatcher->isUsedByParentClassOrInterface($classReflection, $methodName)) {
+            return null;
+        }
+
+        $printedParamTypesString = $this->collectorMetadataPrinter->printParamTypesToString(
+            $node,
+            $classReflection,
+            $scope
+        );
+        return [$classReflection->getName(), $methodName, $printedParamTypesString, $node->getLine()];
+    }
+}

--- a/packages/type-perfect/src/Collector/MethodCall/MethodCallArgTypesCollector.php
+++ b/packages/type-perfect/src/Collector/MethodCall/MethodCallArgTypesCollector.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Collector\MethodCall;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+use PHPStan\Reflection\ExtendedMethodReflection;
+use Rector\TypePerfect\Configuration;
+use Rector\TypePerfect\Matcher\ClassMethodCallReferenceResolver;
+use Rector\TypePerfect\Printer\CollectorMetadataPrinter;
+use Rector\TypePerfect\ValueObject\MethodCallReference;
+
+/**
+ * @implements Collector<MethodCall, array{string, string}>
+ */
+final readonly class MethodCallArgTypesCollector implements Collector
+{
+    public function __construct(
+        private ClassMethodCallReferenceResolver $classMethodCallReferenceResolver,
+        private CollectorMetadataPrinter $collectorMetadataPrinter,
+        private Configuration $configuration
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param MethodCall $node
+     * @return array{string, string}|null
+     */
+    public function processNode(Node $node, Scope $scope): ?array
+    {
+        if (! $this->configuration->isNarrowParamEnabled()) {
+            return null;
+        }
+
+        if ($node->isFirstClassCallable() || $node->getArgs() === [] || ! $node->name instanceof Identifier) {
+            return null;
+        }
+
+        $methodCalledOnType = $scope->getType($node->var);
+        $methodReflection = $scope->getMethodReflection($methodCalledOnType, $node->name->name);
+        if (! $methodReflection instanceof ExtendedMethodReflection) {
+            return null;
+        }
+
+        $classMethodCallReference = $this->classMethodCallReferenceResolver->resolve($node, $scope, true);
+        if (! $classMethodCallReference instanceof MethodCallReference) {
+            return null;
+        }
+
+        $classMethodReference = $this->createClassMethodReference($classMethodCallReference);
+
+        $stringArgTypesString = $this->collectorMetadataPrinter->printArgTypesAsString(
+            $node,
+            $methodReflection,
+            $scope
+        );
+        return [$classMethodReference, $stringArgTypesString];
+    }
+
+    private function createClassMethodReference(MethodCallReference $classMethodCallReference): string
+    {
+        $className = $classMethodCallReference->getClass();
+        $methodName = $classMethodCallReference->getMethod();
+
+        return $className . '::' . $methodName;
+    }
+}

--- a/packages/type-perfect/src/Collector/MethodCallableNode/MethodCallableCollector.php
+++ b/packages/type-perfect/src/Collector/MethodCallableNode/MethodCallableCollector.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Collector\MethodCallableNode;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+use PHPStan\Node\MethodCallableNode;
+use Rector\TypePerfect\Configuration;
+use Rector\TypePerfect\Matcher\ClassMethodCallReferenceResolver;
+use Rector\TypePerfect\ValueObject\MethodCallReference;
+
+/**
+ * @implements Collector<MethodCallableNode, array<string>|null>
+ *
+ * PHPStan has special node for first class callables of MethodCall
+ *
+ * @see https://github.com/phpstan/phpstan-src/blob/511c1e435fb43b8eb0ac310e6aa3230147963790/src/Analyser/NodeScopeResolver.php#L1936
+ */
+final readonly class MethodCallableCollector implements Collector
+{
+    public function __construct(
+        private ClassMethodCallReferenceResolver $classMethodCallReferenceResolver,
+        private Configuration $configuration
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return MethodCallableNode::class;
+    }
+
+    /**
+     * @param MethodCallableNode $node
+     * @return array{string}|null
+     */
+    public function processNode(Node $node, Scope $scope): ?array
+    {
+        if (! $this->configuration->isNarrowParamEnabled()) {
+            return null;
+        }
+
+        $classMethodCallReference = $this->classMethodCallReferenceResolver->resolve($node, $scope, true);
+        if (! $classMethodCallReference instanceof MethodCallReference) {
+            return null;
+        }
+
+        $classMethodReference = $this->createClassMethodReference($classMethodCallReference);
+
+        // special case that should skip everything
+        return [$classMethodReference];
+    }
+
+    private function createClassMethodReference(MethodCallReference $classMethodCallReference): string
+    {
+        $className = $classMethodCallReference->getClass();
+        $methodName = $classMethodCallReference->getMethod();
+
+        return $className . '::' . $methodName;
+    }
+}

--- a/packages/type-perfect/src/Configuration.php
+++ b/packages/type-perfect/src/Configuration.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect;
+
+final class Configuration
+{
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function __construct(
+        private array $parameters
+    ) {
+        // enabed by default in tests
+        if (defined('PHPUNIT_COMPOSER_INSTALL')) {
+            $this->parameters['narrow_param'] = true;
+            $this->parameters['narrow_return'] = true;
+            $this->parameters['no_mixed'] = true;
+            $this->parameters['null_over_false'] = true;
+        }
+    }
+
+    public function isNarrowParamEnabled(): bool
+    {
+        return $this->parameters['narrow_param'] ?? false;
+    }
+
+    public function isNarrowReturnEnabled(): bool
+    {
+        return $this->parameters['narrow_return'] ?? false;
+    }
+
+    public function isNoMixedPropertyEnabled(): bool
+    {
+        if ($this->parameters['no_mixed_property']) {
+            return true;
+        }
+
+        return $this->parameters['no_mixed'] ?? false;
+    }
+
+    public function isNoMixedCallerEnabled(): bool
+    {
+        if ($this->parameters['no_mixed_caller']) {
+            return true;
+        }
+
+        return $this->parameters['no_mixed'] ?? false;
+    }
+
+    public function isNoFalsyReturnEnabled(): bool
+    {
+        return $this->parameters['null_over_false'] ?? false;
+    }
+}

--- a/packages/type-perfect/src/Enum/Types/ResolvedTypes.php
+++ b/packages/type-perfect/src/Enum/Types/ResolvedTypes.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Enum\Types;
+
+final class ResolvedTypes
+{
+    /**
+     * @var string
+     */
+    public const UNKNOWN_TYPES = 'unknown_types';
+}

--- a/packages/type-perfect/src/Guard/EmptyIssetGuard.php
+++ b/packages/type-perfect/src/Guard/EmptyIssetGuard.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Guard;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PhpParser\Node\Expr\Variable;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\TypeCombinator;
+
+final class EmptyIssetGuard
+{
+    public function isLegal(Expr $expr, Scope $scope): bool
+    {
+        if ($expr instanceof ArrayDimFetch) {
+            return true;
+        }
+
+        if (! $expr instanceof Variable) {
+            return true;
+        }
+
+        if ($expr->name instanceof Expr) {
+            return true;
+        }
+
+        if (! $scope->hasVariableType($expr->name)->yes()) {
+            return true;
+        }
+
+        $varType = $scope->getNativeType($expr);
+        $varType = TypeCombinator::removeNull($varType);
+        return $varType->getObjectClassNames() === [];
+    }
+}

--- a/packages/type-perfect/src/Matcher/ClassMethodCallReferenceResolver.php
+++ b/packages/type-perfect/src/Matcher/ClassMethodCallReferenceResolver.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Matcher;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\MethodCallableNode;
+use PHPStan\Type\ThisType;
+use PHPStan\Type\TypeCombinator;
+use Rector\TypePerfect\ValueObject\MethodCallReference;
+
+final class ClassMethodCallReferenceResolver
+{
+    public function resolve(
+        MethodCall|MethodCallableNode $methodCallOrMethodCallable,
+        Scope $scope,
+        bool $allowThisType
+    ): ?MethodCallReference {
+        if ($methodCallOrMethodCallable instanceof MethodCallableNode) {
+            $methodName = $methodCallOrMethodCallable->getName();
+            $variable = $methodCallOrMethodCallable->getVar();
+        } else {
+            $methodName = $methodCallOrMethodCallable->name;
+            $variable = $methodCallOrMethodCallable->var;
+        }
+
+        if ($methodName instanceof Expr) {
+            return null;
+        }
+
+        $callerType = $scope->getType($variable);
+
+        // remove optional nullable type
+        if (TypeCombinator::containsNull($callerType)) {
+            $callerType = TypeCombinator::removeNull($callerType);
+        }
+
+        if (! $allowThisType && $callerType instanceof ThisType) {
+            return null;
+        }
+
+        if (count($callerType->getObjectClassNames()) !== 1) {
+            return null;
+        }
+
+        // move to the class where method is defined, e.g. parent class defines the method, so it should be checked there
+        $className = $callerType->getObjectClassNames()[0];
+        $methodNameString = $methodName->toString();
+
+        return new MethodCallReference($className, $methodNameString);
+    }
+}

--- a/packages/type-perfect/src/Matcher/Collector/PublicClassMethodMatcher.php
+++ b/packages/type-perfect/src/Matcher/Collector/PublicClassMethodMatcher.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Matcher\Collector;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Reflection\ClassReflection;
+
+final class PublicClassMethodMatcher
+{
+    /**
+     * @var string[]
+     */
+    private const SKIPPED_TYPES = [
+        'PHPUnit\Framework\TestCase',
+        'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator',
+    ];
+
+    public function shouldSkipClassReflection(ClassReflection $classReflection): bool
+    {
+        // skip interface as required, traits as unable to detect for sure
+        if (! $classReflection->isClass()) {
+            return true;
+        }
+
+        foreach (self::SKIPPED_TYPES as $skippedType) {
+            if ($classReflection->is($skippedType)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function isUsedByParentClassOrInterface(ClassReflection $classReflection, string $methodName): bool
+    {
+        // is this method required by parent contract? skip it
+        foreach ($classReflection->getInterfaces() as $parentInterfaceReflection) {
+            if ($parentInterfaceReflection->hasMethod($methodName)) {
+                return true;
+            }
+        }
+
+        foreach ($classReflection->getParents() as $parentClassReflection) {
+            if ($parentClassReflection->hasMethod($methodName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function shouldSkipClassMethod(ClassMethod $classMethod): bool
+    {
+        if ($classMethod->isMagic()) {
+            return true;
+        }
+
+        if ($classMethod->isStatic()) {
+            return true;
+        }
+
+        // skip attributes
+        if ($classMethod->attrGroups !== []) {
+            return true;
+        }
+
+        if (! $classMethod->isPublic()) {
+            return true;
+        }
+
+        $doc = $classMethod->getDocComment();
+
+        // skip symfony action
+        return $doc instanceof Doc && str_contains($doc->getText(), '@Route');
+    }
+}

--- a/packages/type-perfect/src/NodeFinder/ClassMethodNodeFinder.php
+++ b/packages/type-perfect/src/NodeFinder/ClassMethodNodeFinder.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\NodeFinder;
+
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use Rector\TypePerfect\Reflection\ReflectionParser;
+
+final readonly class ClassMethodNodeFinder
+{
+    public function __construct(
+        private ReflectionParser $reflectionParser,
+    ) {
+    }
+
+    public function findByMethodCall(MethodCall $methodCall, Scope $scope): ?ClassMethod
+    {
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return null;
+        }
+
+        $classLike = $this->reflectionParser->parseClassReflection($classReflection);
+        if (! $classLike instanceof Class_) {
+            return null;
+        }
+
+        if (! $methodCall->name instanceof Identifier) {
+            return null;
+        }
+
+        $methodCallName = $methodCall->name->toString();
+
+        $classMethod = $classLike->getMethod($methodCallName);
+        if (! $classMethod instanceof ClassMethod) {
+            return null;
+        }
+
+        if (! $classMethod->isPrivate()) {
+            return null;
+        }
+
+        return $classMethod;
+    }
+}

--- a/packages/type-perfect/src/NodeFinder/MethodCallNodeFinder.php
+++ b/packages/type-perfect/src/NodeFinder/MethodCallNodeFinder.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\NodeFinder;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use Rector\TypePerfect\Printer\NodeComparator;
+use Rector\TypePerfect\Reflection\ReflectionParser;
+use Webmozart\Assert\Assert;
+
+final readonly class MethodCallNodeFinder
+{
+    private NodeFinder $nodeFinder;
+
+    public function __construct(
+        private ReflectionParser $reflectionParser,
+        private NodeComparator $nodeComparator,
+    ) {
+        $this->nodeFinder = new NodeFinder();
+    }
+
+    /**
+     * @return MethodCall[]
+     */
+    public function findUsages(MethodCall $methodCall, Scope $scope): array
+    {
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return [];
+        }
+
+        $classLike = $this->reflectionParser->parseClassReflection($classReflection);
+        if (! $classLike instanceof Class_) {
+            return [];
+        }
+
+        $methodCalls = $this->nodeFinder->find($classLike, function (Node $node) use ($methodCall): bool {
+            if (! $node instanceof MethodCall) {
+                return false;
+            }
+
+            if (! $this->nodeComparator->areNodesEqual($node->var, $methodCall->var)) {
+                return false;
+            }
+
+            return $this->nodeComparator->areNodesEqual($node->name, $methodCall->name);
+        });
+
+        Assert::allIsInstanceOf($methodCalls, MethodCall::class);
+
+        return $methodCalls;
+    }
+}

--- a/packages/type-perfect/src/NodeFinder/ReturnNodeFinder.php
+++ b/packages/type-perfect/src/NodeFinder/ReturnNodeFinder.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\NodeFinder;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\NodeTraverser;
+use Rector\TypePerfect\NodeVisitor\CallableNodeVisitor;
+
+final readonly class ReturnNodeFinder
+{
+    public function findOnlyReturnsExpr(ClassMethod $classMethod): Expr|null
+    {
+        $returns = $this->findReturnsWithValues($classMethod);
+        if (count($returns) !== 1) {
+            return null;
+        }
+
+        $onlyReturn = $returns[0];
+        return $onlyReturn->expr;
+    }
+
+    /**
+     * @return Return_[]
+     */
+    public function findReturnsWithValues(ClassMethod $classMethod): array
+    {
+        $returns = [];
+
+        $this->traverseNodesWithCallable((array) $classMethod->stmts, static function (
+            Node $node
+        ) use (&$returns) {
+            // skip different scope
+            if ($node instanceof FunctionLike) {
+                return NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
+            }
+
+            if (! $node instanceof Return_) {
+                return null;
+            }
+
+            if (! $node->expr instanceof Expr) {
+                return null;
+            }
+
+            $returns[] = $node;
+        });
+
+        return $returns;
+    }
+
+    /**
+     * @param callable(Node $node): (int|Node|null) $callable
+     * @param Node[] $nodes
+     */
+    private function traverseNodesWithCallable(array $nodes, callable $callable): void
+    {
+        $nodeTraverser = new NodeTraverser();
+
+        $callableNodeVisitor = new CallableNodeVisitor($callable);
+        $nodeTraverser->addVisitor($callableNodeVisitor);
+        $nodeTraverser->traverse($nodes);
+    }
+}

--- a/packages/type-perfect/src/NodeVisitor/CallableNodeVisitor.php
+++ b/packages/type-perfect/src/NodeVisitor/CallableNodeVisitor.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\NodeVisitorAbstract;
+
+final class CallableNodeVisitor extends NodeVisitorAbstract
+{
+    /**
+     * @var callable(Node): (int|Node|null)
+     */
+    private $callable;
+
+    /**
+     * @param callable(Node $node): (int|Node|null) $callable
+     */
+    public function __construct(callable $callable)
+    {
+        $this->callable = $callable;
+    }
+
+    public function enterNode(Node $node): int|Node|null
+    {
+        $originalNode = $node;
+        $callable = $this->callable;
+
+        /** @var int|Node|null $newNode */
+        $newNode = $callable($node);
+
+        if ($originalNode instanceof Stmt && $newNode instanceof Expr) {
+            return new Expression($newNode);
+        }
+
+        return $newNode;
+    }
+}

--- a/packages/type-perfect/src/PhpDoc/ApiDocStmtAnalyzer.php
+++ b/packages/type-perfect/src/PhpDoc/ApiDocStmtAnalyzer.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\PhpDoc;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\PhpDoc\ResolvedPhpDocBlock;
+use PHPStan\Reflection\ClassReflection;
+
+final class ApiDocStmtAnalyzer
+{
+    public function hasApiDoc(ClassMethod $classMethod, ClassReflection $classReflection): bool
+    {
+        if ($this->hasClassReflectionApiDoc($classReflection)) {
+            return true;
+        }
+
+        $docComment = $classMethod->getDocComment();
+        if (! $docComment instanceof Doc) {
+            return false;
+        }
+
+        return str_contains($docComment->getText(), '@api');
+    }
+
+    private function hasClassReflectionApiDoc(ClassReflection $classReflection): bool
+    {
+        if (! $classReflection->getResolvedPhpDoc() instanceof ResolvedPhpDocBlock) {
+            return false;
+        }
+
+        $resolvedPhpDocBlock = $classReflection->getResolvedPhpDoc();
+        return str_contains($resolvedPhpDocBlock->getPhpDocString(), '@api');
+    }
+}

--- a/packages/type-perfect/src/Printer/CollectorMetadataPrinter.php
+++ b/packages/type-perfect/src/Printer/CollectorMetadataPrinter.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Printer;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\IntersectionType as NodeIntersectionType;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\UnionType;
+use PhpParser\PrettyPrinter\Standard;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\ClosureType;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\IntegerRangeType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\ThisType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType as PHPStanUnionType;
+use PHPStan\Type\VerbosityLevel;
+use Rector\TypePerfect\Enum\Types\ResolvedTypes;
+
+final readonly class CollectorMetadataPrinter
+{
+    private Standard $standard;
+
+    public function __construct(
+    ) {
+        $this->standard = new Standard();
+    }
+
+    public function printArgTypesAsString(
+        MethodCall $methodCall,
+        ExtendedMethodReflection $extendedMethodReflection,
+        Scope $scope
+    ): string {
+        $parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
+            $scope,
+            $methodCall->getArgs(),
+            $extendedMethodReflection->getVariants(),
+            $extendedMethodReflection->getNamedArgumentsVariants()
+        );
+        $parameters = $parametersAcceptor->getParameters();
+
+        $stringArgTypes = [];
+        foreach ($methodCall->getArgs() as $i => $arg) {
+            $argType = $scope->getType($arg->value);
+
+            // we have no idea, nothing we can do
+            if ($argType instanceof MixedType) {
+                return ResolvedTypes::UNKNOWN_TYPES;
+            }
+
+            if ($argType instanceof IntersectionType) {
+                return ResolvedTypes::UNKNOWN_TYPES;
+            }
+
+            if ($argType instanceof GenericObjectType) {
+                return ResolvedTypes::UNKNOWN_TYPES;
+            }
+
+            if ($argType instanceof PHPStanUnionType) {
+                return ResolvedTypes::UNKNOWN_TYPES;
+            }
+
+            if ($argType instanceof ThisType) {
+                $argType = new ObjectType($argType->getClassName());
+            }
+
+            if (array_key_exists($i, $parameters)) {
+                $defaultValueType = $parameters[$i]->getDefaultValue();
+                if ($defaultValueType instanceof Type) {
+                    $argType = TypeCombinator::union($argType, $defaultValueType);
+                }
+            }
+
+            $printedArgType = $this->printTypeToString($argType);
+            $printedArgType = $this->normalizeDateTime($printedArgType);
+
+            $stringArgTypes[] = $printedArgType;
+        }
+
+        return implode('|', $stringArgTypes);
+    }
+
+    public function printParamTypesToString(
+        ClassMethod $classMethod,
+        ClassReflection $classReflection,
+        Scope $scope
+    ): string {
+        $className = $classReflection->getName();
+
+        $parametersReflection = [];
+        if ($classReflection->hasMethod($classMethod->name->name)) {
+            $methodReflection = $classReflection->getMethod($classMethod->name->name, $scope);
+            $variants = $methodReflection->getVariants();
+            if (count($variants) === 1) {
+                $parametersReflection = $variants[0]->getParameters();
+            }
+        }
+
+        $printedParamTypes = [];
+        foreach ($classMethod->params as $i => $param) {
+            if ($param->type === null) {
+                $printedParamTypes[] = '';
+                continue;
+            }
+
+            $phpdocType = null;
+            if (array_key_exists($i, $parametersReflection)) {
+                $paramphpdocType = $parametersReflection[$i]->getPhpDocType();
+                if (! $paramphpdocType instanceof MixedType) {
+                    $phpdocType = $paramphpdocType;
+                }
+            }
+
+            if ($phpdocType instanceof Type) {
+                $printedParamType = $this->printTypeToString($phpdocType);
+            } else {
+                $paramType = $this->transformSelfToClassName($param->type, $className);
+
+                if ($paramType instanceof NullableType) {
+                    // unite to phpstan type
+                    $paramType = new UnionType([$paramType->type, new Identifier('null')]);
+                }
+
+                if ($paramType instanceof UnionType || $paramType instanceof NodeIntersectionType) {
+                    $paramType = $this->resolveSortedTypes($paramType, $className);
+                }
+
+                $printedParamType = $this->standard->prettyPrint([$paramType]);
+                $printedParamType = str_replace('\Closure', 'callable', $printedParamType);
+                $printedParamType = ltrim($printedParamType, '\\');
+                $printedParamType = str_replace('|\\', '|', $printedParamType);
+            }
+
+            // to avoid DateTime vs DateTimeImmutable vs DateTimeInterface conflicts
+            $printedParamType = $this->normalizeDateTime($printedParamType);
+
+            $printedParamTypes[] = $printedParamType;
+        }
+
+        return implode('|', $printedParamTypes);
+    }
+
+    private function transformSelfToClassName(Node $node, ?string $className): Node
+    {
+        if (! $node instanceof Name || $className === null) {
+            return $node;
+        }
+
+        if ($node->toString() !== 'self') {
+            return $node;
+        }
+
+        return new FullyQualified($className);
+    }
+
+    private function resolveSortedTypes(
+        UnionType|NodeIntersectionType $paramType,
+        ?string $className
+    ): UnionType|NodeIntersectionType {
+        $typeNames = [];
+
+        foreach ($paramType->types as $type) {
+            if ($type instanceof NodeIntersectionType) {
+                foreach ($type->types as $intersectionType) {
+                    /** @var Identifier|Name $intersectionType */
+                    $intersectionType = $this->transformSelfToClassName($intersectionType, $className);
+                    $typeNames[] = (string) $intersectionType;
+                }
+
+                continue;
+            }
+
+            /** @var Identifier|Name $type */
+            $type = $this->transformSelfToClassName($type, $className);
+            $typeNames[] = (string) $type;
+        }
+
+        sort($typeNames);
+
+        $types = [];
+        foreach ($typeNames as $typeName) {
+            $types[] = new Identifier($typeName);
+        }
+
+        if ($paramType instanceof NodeIntersectionType) {
+            return new NodeIntersectionType($types);
+        }
+
+        return new UnionType($types);
+    }
+
+    private function printTypeToString(Type $type): string
+    {
+        if ($type->isClassString()->yes()) {
+            return 'string';
+        }
+
+        if ($type->isArray()->yes()) {
+            return 'array';
+        }
+
+        if ($type->isBoolean()->yes()) {
+            return 'bool';
+        }
+
+        if ($type instanceof IntegerRangeType) {
+            return 'int';
+        }
+
+        if ($type instanceof ClosureType) {
+            return 'callable';
+        }
+
+        if (count($type->getEnumCases()) === 1) {
+            return $type->getEnumCases()[0]
+                ->getClassName();
+        }
+
+        return $type->describe(VerbosityLevel::typeOnly());
+    }
+
+    private function normalizeDateTime(string $printedType): string
+    {
+        if ($printedType === 'DateTimeImmutable') {
+            return 'DateTimeInterface';
+        }
+
+        if ($printedType === 'DateTime') {
+            return 'DateTimeInterface';
+        }
+
+        return $printedType;
+    }
+}

--- a/packages/type-perfect/src/Printer/NodeComparator.php
+++ b/packages/type-perfect/src/Printer/NodeComparator.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Printer;
+
+use PhpParser\Node;
+use PHPStan\Node\Printer\Printer;
+
+final readonly class NodeComparator
+{
+    public function __construct(
+        private Printer $printer
+    ) {
+    }
+
+    public function areNodesEqual(Node $firstNode, Node $secondNode): bool
+    {
+        // remove comments from nodes
+        $firstNode->setAttribute('comments', null);
+        $secondNode->setAttribute('comments', null);
+
+        return $this->printer->prettyPrint([$firstNode]) === $this->printer->prettyPrint([$secondNode]);
+    }
+}

--- a/packages/type-perfect/src/Reflection/MethodNodeAnalyser.php
+++ b/packages/type-perfect/src/Reflection/MethodNodeAnalyser.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Reflection;
+
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+
+final class MethodNodeAnalyser
+{
+    public function hasParentVendorLock(Scope $scope, string $methodName): bool
+    {
+        return $this->matchFirstParentClassMethod($scope, $methodName) instanceof MethodReflection;
+    }
+
+    public function matchFirstParentClassMethod(Scope $scope, string $methodName): ?MethodReflection
+    {
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return null;
+        }
+
+        // the classes have highter priority, e.g. priority in class covariance
+        foreach ($classReflection->getParents() as $parentClassReflection) {
+            if ($parentClassReflection->hasNativeMethod($methodName)) {
+                return $parentClassReflection->getNativeMethod($methodName);
+            }
+        }
+
+        foreach ($classReflection->getAncestors() as $ancestorClassReflection) {
+            if ($classReflection === $ancestorClassReflection) {
+                continue;
+            }
+
+            if (! $ancestorClassReflection->hasNativeMethod($methodName)) {
+                continue;
+            }
+
+            return $ancestorClassReflection->getNativeMethod($methodName);
+        }
+
+        return null;
+    }
+}

--- a/packages/type-perfect/src/Reflection/ReflectionParser.php
+++ b/packages/type-perfect/src/Reflection/ReflectionParser.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Reflection;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+use PHPStan\Reflection\ClassReflection;
+use Throwable;
+
+final class ReflectionParser
+{
+    /**
+     * @var array<string, ClassLike>
+     */
+    private array $classesByFilename = [];
+
+    private readonly Parser $parser;
+
+    public function __construct()
+    {
+        $parserFactory = new ParserFactory();
+        $this->parser = $parserFactory->createForNewestSupportedVersion();
+    }
+
+    public function parseClassReflection(ClassReflection $classReflection): ?ClassLike
+    {
+        $fileName = $classReflection->getFileName();
+        if ($fileName === null) {
+            return null;
+        }
+
+        return $this->parseFilenameToClass($fileName);
+    }
+
+    private function parseFilenameToClass(string $fileName): ClassLike|null
+    {
+        if (isset($this->classesByFilename[$fileName])) {
+            return $this->classesByFilename[$fileName];
+        }
+
+        try {
+            /** @var string $fileContents */
+            $fileContents = file_get_contents($fileName);
+
+            $stmts = $this->parser->parse($fileContents);
+            if (! is_array($stmts)) {
+                return null;
+            }
+
+            // complete namespacedName variables
+            $nodeTraverser = new NodeTraverser();
+            $nodeTraverser->addVisitor(new NameResolver());
+            $nodeTraverser->traverse($stmts);
+        } catch (Throwable) {
+            // not reachable
+            return null;
+        }
+
+        $classLike = $this->findFirstClassLike($stmts);
+        if (! $classLike instanceof ClassLike) {
+            return null;
+        }
+
+        $this->classesByFilename[$fileName] = $classLike;
+
+        return $classLike;
+    }
+
+    /**
+     * @param Node[] $nodes
+     */
+    private function findFirstClassLike(array $nodes): ?ClassLike
+    {
+        $nodeFinder = new NodeFinder();
+        return $nodeFinder->findFirstInstanceOf($nodes, ClassLike::class);
+    }
+}

--- a/packages/type-perfect/src/Rules/NarrowPrivateClassMethodParamTypeRule.php
+++ b/packages/type-perfect/src/Rules/NarrowPrivateClassMethodParamTypeRule.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Generic\TemplateType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\UnionType;
+use PHPStan\Type\VerbosityLevel;
+use Rector\TypePerfect\Configuration;
+use Rector\TypePerfect\NodeFinder\ClassMethodNodeFinder;
+use Rector\TypePerfect\NodeFinder\MethodCallNodeFinder;
+
+/**
+ * @see \Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\NarrowPrivateClassMethodParamTypeRuleTest
+ * @implements Rule<MethodCall>
+ */
+final readonly class NarrowPrivateClassMethodParamTypeRule implements Rule
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Parameter %d should use "%s" type as the only type passed to this method';
+
+    public function __construct(
+        private Configuration $configuration,
+        private MethodCallNodeFinder $methodCallNodeFinder,
+        private ClassMethodNodeFinder $classMethodNodeFinder
+    ) {
+    }
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param MethodCall $node
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $this->configuration->isNarrowParamEnabled() || $node->isFirstClassCallable()) {
+            return [];
+        }
+
+        $args = $node->getArgs();
+        if ($args === []) {
+            return [];
+        }
+
+        if (! $node->var instanceof Variable) {
+            return [];
+        }
+
+        if (! is_string($node->var->name)) {
+            return [];
+        }
+
+        if ($node->var->name !== 'this') {
+            return [];
+        }
+
+        return $this->validateArgVsParamTypes($args, $node, $scope);
+    }
+
+    /**
+     * @param Arg[] $args
+     * @return RuleError[]
+     */
+    private function validateArgVsParamTypes(array $args, MethodCall $methodCall, Scope $scope): array
+    {
+        $methodCallUses = $this->methodCallNodeFinder->findUsages($methodCall, $scope);
+        if (count($methodCallUses) > 1) {
+            return [];
+        }
+
+        $classMethod = $this->classMethodNodeFinder->findByMethodCall($methodCall, $scope);
+        if (! $classMethod instanceof ClassMethod) {
+            return [];
+        }
+
+        /** @var Param[] $params */
+        $params = $classMethod->getParams();
+
+        $errorMessages = [];
+
+        foreach ($args as $position => $arg) {
+            $param = $params[$position] ?? [];
+            if (! $param instanceof Param) {
+                continue;
+            }
+
+            if ($param->variadic) {
+                return [];
+            }
+
+            $paramRuleError = $this->validateParam($param, $position, $arg->value, $scope);
+            if (! $paramRuleError instanceof RuleError) {
+                continue;
+            }
+
+            // @todo test double failed type
+            $errorMessages[] = $paramRuleError;
+        }
+
+        return $errorMessages;
+    }
+
+    private function validateParam(Param $param, int $position, Expr $expr, Scope $scope): ?RuleError
+    {
+        $type = $param->type;
+
+        // @todo some static type mapper from php-parser to PHPStan?
+        if (! $type instanceof FullyQualified) {
+            return null;
+        }
+
+        $argType = $scope->getType($expr);
+        if ($argType instanceof MixedType) {
+            return null;
+        }
+
+        if ($argType instanceof TemplateType) {
+            return null;
+        }
+
+        // not solveable yet, work with PHP 8 code only
+        if ($argType instanceof UnionType) {
+            return null;
+        }
+
+        if ($argType instanceof IntersectionType || $argType instanceof GenericObjectType) {
+            return null;
+        }
+
+        $objectType = new ObjectType($type->toString());
+
+        if ($objectType->equals($argType)) {
+            return null;
+        }
+
+        $classReflection = $objectType->getClassReflection();
+        if ($classReflection instanceof ClassReflection && $classReflection->isAbstract()) {
+            return null;
+        }
+
+        // handle weird type substration cases
+        $paramTypeAsString = $objectType->describe(VerbosityLevel::typeOnly());
+        $argTypeAsString = $argType->describe(VerbosityLevel::typeOnly());
+
+        if ($paramTypeAsString === $argTypeAsString) {
+            return null;
+        }
+
+        $errorMessage = sprintf(self::ERROR_MESSAGE, $position + 1, $argTypeAsString);
+
+        return RuleErrorBuilder::message($errorMessage)
+            ->identifier('typePerfect.narrowPrivateClassMethodParamType')
+            ->line($param->getLine())
+            ->build();
+    }
+}

--- a/packages/type-perfect/src/Rules/NarrowPublicClassMethodParamTypeRule.php
+++ b/packages/type-perfect/src/Rules/NarrowPublicClassMethodParamTypeRule.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Rules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\CollectedDataNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use Rector\TypePerfect\Collector\ClassMethod\PublicClassMethodParamTypesCollector;
+use Rector\TypePerfect\Collector\MethodCall\MethodCallArgTypesCollector;
+use Rector\TypePerfect\Collector\MethodCallableNode\MethodCallableCollector;
+use Rector\TypePerfect\Configuration;
+use Rector\TypePerfect\Enum\Types\ResolvedTypes;
+
+/**
+ * @see \Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\NarrowPublicClassMethodParamTypeRuleTest
+ *
+ * @implements Rule<CollectedDataNode>
+ */
+final readonly class NarrowPublicClassMethodParamTypeRule implements Rule
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Parameters should have "%s" types as the only types passed to this method';
+
+    public function __construct(
+        private Configuration $configuration
+    ) {
+    }
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return CollectedDataNode::class;
+    }
+
+    /**
+     * @param CollectedDataNode $node
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $this->configuration->isNarrowParamEnabled()) {
+            return [];
+        }
+
+        $publicClassMethodCollector = $node->get(PublicClassMethodParamTypesCollector::class);
+        $classMethodReferenceToArgTypes = $this->resolveClassMethodReferenceToArgTypes($node);
+
+        $ruleErrors = [];
+
+        foreach ($publicClassMethodCollector as $filePath => $declarations) {
+            foreach ($declarations as [$className, $methodName, $paramTypesString, $line]) {
+                $uniqueCollectedArgTypesString = $this->resolveUniqueArgTypesString(
+                    $classMethodReferenceToArgTypes,
+                    $className,
+                    $methodName
+                );
+
+                if ($uniqueCollectedArgTypesString === null) {
+                    continue;
+                }
+
+                if ($paramTypesString === $uniqueCollectedArgTypesString) {
+                    continue;
+                }
+
+                $ruleErrors[] = RuleErrorBuilder::message(sprintf(self::ERROR_MESSAGE, $uniqueCollectedArgTypesString))
+                    ->identifier('typePerfect.narrowPublicClassMethodParamType')
+                    ->file($filePath)
+                    ->line($line)
+                    ->build();
+            }
+        }
+
+        return $ruleErrors;
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    private function resolveClassMethodReferenceToArgTypes(CollectedDataNode $collectedDataNode): array
+    {
+        $methodCallArgTypesByFilePath = $collectedDataNode->get(MethodCallArgTypesCollector::class);
+
+        // these should be skipped completely, as we have no idea what is being passed there
+        $methodCallablesByFilePath = $collectedDataNode->get(MethodCallableCollector::class);
+
+        $methodFirstClassCallables = $this->flattenCollectedData($methodCallablesByFilePath);
+
+        // group call references and types
+        $classMethodReferenceToTypes = [];
+
+        foreach ($methodCallArgTypesByFilePath as $methodCallArgTypes) {
+            foreach ($methodCallArgTypes as [$classMethodReference, $argTypesString]) {
+                // skip it
+                if (in_array($classMethodReference, $methodFirstClassCallables, true)) {
+                    continue;
+                }
+
+                $classMethodReferenceToTypes[$classMethodReference][] = $argTypesString;
+            }
+        }
+
+        // resolve unique values
+        foreach ($classMethodReferenceToTypes as $key => $value) {
+            $classMethodReferenceToTypes[$key] = array_unique($value);
+        }
+
+        return $classMethodReferenceToTypes;
+    }
+
+    /**
+     * @param array<string, string[]> $classMethodReferenceToArgTypes
+     */
+    private function resolveUniqueArgTypesString(
+        array $classMethodReferenceToArgTypes,
+        string $className,
+        string $methodName
+    ): ?string {
+        $currentClassMethodReference = $className . '::' . $methodName;
+
+        $collectedArgTypes = $classMethodReferenceToArgTypes[$currentClassMethodReference] ?? null;
+        if ($collectedArgTypes === null) {
+            return null;
+        }
+
+        // we need exactly one type
+        if (count($collectedArgTypes) !== 1) {
+            return null;
+        }
+
+        // one of the arg types could not be resolved, we're not sure
+        if (in_array(ResolvedTypes::UNKNOWN_TYPES, $collectedArgTypes, true)) {
+            return null;
+        }
+
+        return $collectedArgTypes[0];
+    }
+
+    /**
+     * @param mixed[] $methodCallablesByFilePath
+     * @return mixed[]
+     */
+    private function flattenCollectedData(array $methodCallablesByFilePath): array
+    {
+        $methodFirstClassCallables = [];
+        foreach ($methodCallablesByFilePath as $methodCallables) {
+            foreach ($methodCallables as $methodCallable) {
+                $methodFirstClassCallables[] = $methodCallable[0];
+            }
+        }
+
+        return $methodFirstClassCallables;
+    }
+}

--- a/packages/type-perfect/src/Rules/NarrowReturnObjectTypeRule.php
+++ b/packages/type-perfect/src/Rules/NarrowReturnObjectTypeRule.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use Rector\TypePerfect\Configuration;
+use Rector\TypePerfect\NodeFinder\ReturnNodeFinder;
+use Rector\TypePerfect\Reflection\MethodNodeAnalyser;
+
+/**
+ * @see \Rector\TypePerfect\Tests\Rules\NarrowReturnObjectTypeRule\NarrowReturnObjectTypeRuleTest
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class NarrowReturnObjectTypeRule implements Rule
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Provide more specific return type "%s" over abstract one';
+
+    public function __construct(
+        private ReturnNodeFinder $returnNodeFinder,
+        private MethodNodeAnalyser $methodNodeAnalyser,
+        private Configuration $configuration
+    ) {
+    }
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @param ClassMethod $node
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $this->configuration->isNarrowReturnEnabled()) {
+            return [];
+        }
+
+        if (! $node->returnType instanceof FullyQualified) {
+            return [];
+        }
+
+        if ($this->shouldSkipScope($scope)) {
+            return [];
+        }
+
+        $returnObjectType = new ObjectType($node->returnType->toString());
+        if ($this->shouldSkipReturnObjectType($returnObjectType)) {
+            return [];
+        }
+
+        $methodName = $node->name->toString();
+        if ($this->methodNodeAnalyser->hasParentVendorLock($scope, $methodName)) {
+            return [];
+        }
+
+        $returnExpr = $this->returnNodeFinder->findOnlyReturnsExpr($node);
+        if (! $returnExpr instanceof Expr) {
+            return [];
+        }
+
+        $returnExprType = $scope->getType($returnExpr);
+        if ($this->shouldSkipReturnExprType($returnExprType)) {
+            return [];
+        }
+
+        if ($returnObjectType->equals($returnExprType)) {
+            return [];
+        }
+
+        // is subtype?
+        if (! $returnObjectType->isSuperTypeOf($returnExprType)->yes()) {
+            return [];
+        }
+
+        if (count($returnExprType->getObjectClassNames()) !== 1) {
+            return [];
+        }
+
+        $errorMessage = sprintf(self::ERROR_MESSAGE, $returnExprType->getObjectClassNames()[0]);
+
+        return [
+            RuleErrorBuilder::message($errorMessage)
+                ->identifier('typePerfect.narrowReturnObjectType')
+                ->build(),
+        ];
+    }
+
+    private function shouldSkipReturnObjectType(ObjectType $objectType): bool
+    {
+        $classReflection = $objectType->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return true;
+        }
+
+        // cannot be more precise if final class
+        return $classReflection->isFinal();
+    }
+
+    private function shouldSkipScope(Scope $scope): bool
+    {
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return true;
+        }
+
+        return ! $classReflection->isClass();
+    }
+
+    private function shouldSkipReturnExprType(Type $type): bool
+    {
+        if (count($type->getObjectClassNames()) !== 1) {
+            return true;
+        }
+
+        if (count($type->getObjectClassReflections()) !== 1) {
+            return true;
+        }
+
+        return $type->getObjectClassReflections()[0]
+            ->isAnonymous();
+    }
+}

--- a/packages/type-perfect/src/Rules/NoArrayAccessOnObjectRule.php
+++ b/packages/type-perfect/src/Rules/NoArrayAccessOnObjectRule.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrayDimFetch;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+/**
+ * @see \Rector\TypePerfect\Tests\Rules\NoArrayAccessOnObjectRule\NoArrayAccessOnObjectRuleTest
+ * @implements Rule<ArrayDimFetch>
+ */
+final class NoArrayAccessOnObjectRule implements Rule
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Use explicit methods over array access on object';
+
+    /**
+     * @var string[]
+     */
+    private const ALLOWED_CLASSES = [
+        'SplFixedArray',
+        'SimpleXMLElement',
+        'Iterator',
+        'WeakMap',
+        'Aws\ResultInterface',
+        'Symfony\Component\Form\FormInterface',
+        'Symfony\Component\OptionsResolver\Options',
+    ];
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return ArrayDimFetch::class;
+    }
+
+    /**
+     * @param ArrayDimFetch $node
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $varType = $scope->getType($node->var);
+        if (! $varType instanceof ObjectType) {
+            return [];
+        }
+
+        if ($this->isAllowedObjectType($varType)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(self::ERROR_MESSAGE)
+                ->identifier('typePerfect.noArrayAccessOnObject')
+                ->build(),
+        ];
+    }
+
+    private function isAllowedObjectType(ObjectType $objectType): bool
+    {
+        foreach (self::ALLOWED_CLASSES as $allowedClass) {
+            if ($objectType->isInstanceOf($allowedClass)->yes()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/packages/type-perfect/src/Rules/NoArrayAccessOnObjectRule.php
+++ b/packages/type-perfect/src/Rules/NoArrayAccessOnObjectRule.php
@@ -32,6 +32,7 @@ final class NoArrayAccessOnObjectRule implements Rule
         'Iterator',
         'WeakMap',
         'Aws\ResultInterface',
+        'Symfony\Component\DomCrawler\AbstractUriElement',
         'Symfony\Component\Form\FormInterface',
         'Symfony\Component\OptionsResolver\Options',
     ];

--- a/packages/type-perfect/src/Rules/NoEmptyOnObjectRule.php
+++ b/packages/type-perfect/src/Rules/NoEmptyOnObjectRule.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Empty_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use Rector\TypePerfect\Guard\EmptyIssetGuard;
+
+/**
+ * @implements Rule<Empty_>
+ */
+final readonly class NoEmptyOnObjectRule implements Rule
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Use instanceof instead of empty() on object';
+
+    public function __construct(
+        private EmptyIssetGuard $emptyIssetGuard
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return Empty_::class;
+    }
+
+    /**
+     * @param Empty_ $node
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($this->emptyIssetGuard->isLegal($node->expr, $scope)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(self::ERROR_MESSAGE)
+                ->identifier('typePerfect.noEmptyOnObject')
+                ->build(),
+        ];
+    }
+}

--- a/packages/type-perfect/src/Rules/NoIssetOnObjectRule.php
+++ b/packages/type-perfect/src/Rules/NoIssetOnObjectRule.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Isset_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use Rector\TypePerfect\Guard\EmptyIssetGuard;
+
+/**
+ * @see \Rector\TypePerfect\Tests\Rules\NoIssetOnObjectRule\NoIssetOnObjectRuleTest
+ * @implements Rule<Isset_>
+ */
+final readonly class NoIssetOnObjectRule implements Rule
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Use instanceof instead of isset() on object';
+
+    public function __construct(
+        private EmptyIssetGuard $emptyIssetGuard
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return Isset_::class;
+    }
+
+    /**
+     * @param Isset_ $node
+     *
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        foreach ($node->vars as $var) {
+            if ($this->emptyIssetGuard->isLegal($var, $scope)) {
+                continue;
+            }
+
+            return [
+                RuleErrorBuilder::message(self::ERROR_MESSAGE)
+                    ->identifier('typePerfect.noIssetOnObject')
+                    ->build(),
+            ];
+        }
+
+        return [];
+    }
+}

--- a/packages/type-perfect/src/Rules/NoMixedMethodCallerRule.php
+++ b/packages/type-perfect/src/Rules/NoMixedMethodCallerRule.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\Printer\Printer;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\MixedType;
+use Rector\TypePerfect\Configuration;
+
+/**
+ * @see \Rector\TypePerfect\Tests\Rules\NoMixedMethodCallerRule\NoMixedMethodCallerRuleTest
+ * @implements Rule<MethodCall>
+ */
+final readonly class NoMixedMethodCallerRule implements Rule
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Mixed variable in a `%s->...()` can skip important errors. Make sure the type is known';
+
+    public function __construct(
+        private Printer $printer,
+        private Configuration $configuration,
+    ) {
+    }
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param MethodCall $node
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $this->configuration->isNoMixedCallerEnabled()) {
+            return [];
+        }
+
+        $callerType = $scope->getType($node->var);
+
+        if (! $callerType instanceof MixedType) {
+            return [];
+        }
+
+        if ($callerType instanceof ErrorType) {
+            return [];
+        }
+
+        // if error, skip as well for false positive
+        if ($this->isPreviousTypeErrorType($node, $scope)) {
+            return [];
+        }
+
+        $printedMethodCall = $this->printer->prettyPrintExpr($node->var);
+
+        return [
+            RuleErrorBuilder::message(sprintf(self::ERROR_MESSAGE, $printedMethodCall))
+                ->identifier('typePerfect.noMixedMethodCaller')
+                ->build(),
+        ];
+    }
+
+    private function isPreviousTypeErrorType(MethodCall $methodCall, Scope $scope): bool
+    {
+        $currentMethodCall = $methodCall;
+        while ($currentMethodCall->var instanceof MethodCall) {
+            $previousType = $scope->getType($currentMethodCall->var);
+            if ($previousType instanceof ErrorType) {
+                return true;
+            }
+
+            $currentMethodCall = $currentMethodCall->var;
+        }
+
+        return false;
+    }
+}

--- a/packages/type-perfect/src/Rules/NoMixedPropertyFetcherRule.php
+++ b/packages/type-perfect/src/Rules/NoMixedPropertyFetcherRule.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\PropertyFetch;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\Printer\Printer;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\MixedType;
+use Rector\TypePerfect\Configuration;
+
+/**
+ * @see \Rector\TypePerfect\Tests\Rules\NoMixedPropertyFetcherRule\NoMixedPropertyFetcherRuleTest
+ * @implements Rule<PropertyFetch>
+ */
+final readonly class NoMixedPropertyFetcherRule implements Rule
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Mixed property fetch in a "%s->..." can skip important errors. Make sure the type is known';
+
+    public function __construct(
+        private Printer $printer,
+        private Configuration $configuration,
+    ) {
+    }
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return PropertyFetch::class;
+    }
+
+    /**
+     * @param PropertyFetch $node
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $this->configuration->isNoMixedPropertyEnabled()) {
+            return [];
+        }
+
+        $callerType = $scope->getType($node->var);
+        if (! $callerType instanceof MixedType) {
+            return [];
+        }
+
+        $printedVar = $this->printer->prettyPrintExpr($node->var);
+
+        return [
+            RuleErrorBuilder::message(sprintf(self::ERROR_MESSAGE, $printedVar))
+                ->identifier('typePerfect.noMixedPropertyFetcher')
+                ->build(),
+        ];
+    }
+}

--- a/packages/type-perfect/src/Rules/NoParamTypeRemovalRule.php
+++ b/packages/type-perfect/src/Rules/NoParamTypeRemovalRule.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\Php\PhpMethodReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
+use Rector\TypePerfect\Reflection\MethodNodeAnalyser;
+
+/**
+ * @see \Rector\TypePerfect\Tests\Rules\ForbiddenParamTypeRemovalRule\ForbiddenParamTypeRemovalRuleTest
+ * @implements Rule<ClassMethod>
+ */
+final readonly class NoParamTypeRemovalRule implements Rule
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Removing parent param type is forbidden';
+
+    public function __construct(
+        private MethodNodeAnalyser $methodNodeAnalyser
+    ) {
+    }
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @param ClassMethod $node
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->params === []) {
+            return [];
+        }
+
+        $classMethodName = (string) $node->name;
+        if ($classMethodName === '__construct') {
+            return [];
+        }
+
+        $parentClassMethodReflection = $this->methodNodeAnalyser->matchFirstParentClassMethod($scope, $classMethodName);
+        if (! $parentClassMethodReflection instanceof PhpMethodReflection) {
+            return [];
+        }
+
+        foreach ($node->params as $paramPosition => $param) {
+            if ($param->type !== null) {
+                continue;
+            }
+
+            $parentParamType = $this->resolveParentParamType($parentClassMethodReflection, $paramPosition);
+            if ($parentParamType instanceof MixedType) {
+                continue;
+            }
+
+            // removed param type!
+            return [
+                RuleErrorBuilder::message(self::ERROR_MESSAGE)
+                    ->identifier('typePerfect.noParamTypeRemoval')
+                    ->build(),
+            ];
+        }
+
+        return [];
+    }
+
+    private function resolveParentParamType(PhpMethodReflection $phpMethodReflection, int $paramPosition): Type
+    {
+        foreach ($phpMethodReflection->getVariants() as $extendedParametersAcceptor) {
+            foreach ($extendedParametersAcceptor->getParameters() as $parentParamPosition => $parameterReflectionWithPhpDoc) {
+                if ($paramPosition !== $parentParamPosition) {
+                    continue;
+                }
+
+                return $parameterReflectionWithPhpDoc->getNativeType();
+            }
+        }
+
+        return new MixedType();
+    }
+}

--- a/packages/type-perfect/src/Rules/ReturnNullOverFalseRule.php
+++ b/packages/type-perfect/src/Rules/ReturnNullOverFalseRule.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Return_;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use Rector\TypePerfect\Configuration;
+
+/**
+ * @implements Rule<ClassMethod>
+ */
+final readonly class ReturnNullOverFalseRule implements Rule
+{
+    /**
+     * @api
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Returning false in non return bool class method. Use null with type|null instead or add bool return type';
+
+    private NodeFinder $nodeFinder;
+
+    public function __construct(
+        private Configuration $configuration,
+    ) {
+        $this->nodeFinder = new NodeFinder();
+    }
+
+    /**
+     * @return class-string<Node>
+     */
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @param ClassMethod $node
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $this->configuration->isNoFalsyReturnEnabled()) {
+            return [];
+        }
+
+        if ($node->stmts === null) {
+            return [];
+        }
+
+        if ($node->returnType instanceof Node) {
+            return [];
+        }
+
+        /** @var Return_[] $returns */
+        $returns = $this->nodeFinder->findInstanceOf($node->stmts, Return_::class);
+
+        $hasFalseType = false;
+        $hasTrueType = false;
+
+        foreach ($returns as $return) {
+            if (! $return->expr instanceof Expr) {
+                continue;
+            }
+
+            $exprType = $scope->getType($return->expr);
+            if (! $exprType instanceof ConstantBooleanType) {
+                if ($exprType->isBoolean()->yes()) {
+                    return [];
+                }
+
+                continue;
+            }
+
+            if ($exprType->getValue()) {
+                $hasTrueType = true;
+                continue;
+            }
+
+            $hasFalseType = true;
+        }
+
+        if (! $hasTrueType && $hasFalseType) {
+            return [
+                RuleErrorBuilder::message(self::ERROR_MESSAGE)
+                    ->identifier('typePerfect.nullOverFalse')
+                    ->build(),
+            ];
+        }
+
+        return [];
+    }
+}

--- a/packages/type-perfect/src/ValueObject/MethodCallReference.php
+++ b/packages/type-perfect/src/ValueObject/MethodCallReference.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\ValueObject;
+
+final readonly class MethodCallReference
+{
+    public function __construct(
+        private string $class,
+        private string $method
+    ) {
+    }
+
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/DifferentClassSameMethodCallName.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/DifferentClassSameMethodCallName.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Source\AnotherClassWithRun;
+use Rector\TypePerfect\Tests\Rules\PreferredClassRule\Fixture\SomeStaticCall;
+
+class DifferentClassSameMethodCallName
+{
+    /**
+     * @param SomeStaticCall|MethodCall $node
+     */
+    public function process(AnotherClassWithRun $anotherClassWithRun)
+    {
+        $anotherClassWithRun->run($anotherClassWithRun);
+    }
+
+    /**
+     * @param SomeStaticCall|MethodCall $node
+     */
+    private function run(Node $node)
+    {
+        if ($node->name instanceof MethodCall) {
+            $this->run($node->name);
+        }
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/DoubleShot.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/DoubleShot.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Fixture;
+
+use PhpParser\Node;
+
+class DoubleShot
+{
+    public function run(Node\Arg $arg, Node\Param $param)
+    {
+        $this->isCheck($arg, $param);
+    }
+    private function isCheck(\PhpParser\Node $arg, \PhpParser\Node $param)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/Fixture.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/Fixture.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+
+class Fixture
+{
+    public function run(Node $node)
+    {
+        if ($node instanceof MethodCall) {
+            $this->isCheck($node);
+        }
+    }
+
+    private function isCheck(Node $node)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipAbstractBase.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipAbstractBase.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SkipAbstractBase;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Source\ConceptBase;
+use Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Source\ConceptImpl1;
+
+class MyService {
+    public function run(ConceptImpl1 $arg)
+    {
+        $this->isCheck($arg);
+    }
+    private function isCheck(ConceptBase $arg)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipAlreadyCorrectType.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipAlreadyCorrectType.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+
+class SkipAlreadyCorrectType
+{
+    public function run(Node $node)
+    {
+        if ($node instanceof MethodCall) {
+            $this->isCheck($node);
+        }
+    }
+
+    private function isCheck(MethodCall $node)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipCorrectUnionType.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipCorrectUnionType.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Fixture;
+
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Stmt\Return_;
+
+final class SkipCorrectUnionType
+{
+    public function run(\PhpParser\Node $node)
+    {
+        if (! $node instanceof Assign && ! $node instanceof Return_) {
+            return [];
+        }
+
+        if (! $this->isIncludeOnceOrRequireOnce($node)) {
+            return [];
+        }
+
+        return [];
+    }
+
+    /**
+     * @param Assign|Return_ $node
+     */
+    private function isIncludeOnceOrRequireOnce(\PhpParser\Node $node)
+    {
+        return true;
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipDuplicatedCallOfSameMethodWithComment.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipDuplicatedCallOfSameMethodWithComment.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Fixture;
+
+use PHPStan\Node\FileNode;
+use Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace;
+
+final class SkipDuplicatedCallOfSameMethodWithComment2
+{
+    public function firstMethod()
+    {
+        $this->printFile(new FileWithoutNamespace([]));
+    }
+
+    private function printFile(\PhpParser\Node $node)
+    {
+    }
+
+    public function secondMethod()
+    {
+        // some comment
+        $this->printFile(new FileNode([]));
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipGenericType.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipGenericType.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+
+/**
+ * @template T of MethodCall
+ */
+class SkipGenericType
+{
+    /**
+     * @param T $node
+     * @return void
+     */
+    public function run(Node $node)
+    {
+        $this->getsAGeneric($node);
+    }
+
+    /**
+     * @param T $node
+     * @return void
+     */
+    private function getsAGeneric(Node $node)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipMayOverrideArg.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipMayOverrideArg.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+
+class SkipMayOverrideArg
+{
+    public function run(Node $node)
+    {
+        if ($node instanceof MethodCall) {
+
+            // on this part, $node may be overriden
+            $node = $this->mayOverrideNode();
+
+            $this->isCheck($node);
+
+        }
+    }
+
+    private function isCheck(Node $node)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipMixed.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipMixed.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Fixture;
+
+use PhpParser\Node;
+
+class SkipMixed
+{
+    public function run($arg)
+    {
+        $this->isCheck($arg);
+    }
+    private function isCheck(\PhpParser\Node $arg)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipMultipleUsed.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipMultipleUsed.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+
+class SkipMultipleUsed
+{
+    public function run(Node $node)
+    {
+        if ($node instanceof MethodCall) {
+            $this->isCheck($node);
+        }
+
+        if ($node instanceof PropertyFetch) {
+            $this->isCheck($node);
+        }
+    }
+
+    private function isCheck(Node $node)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipNoArgs.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipNoArgs.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Fixture;
+
+use PhpParser\Node;
+
+final class SkipNoArgs
+{
+    public function run()
+    {
+        $this->execute();
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipNotFromThis.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipNotFromThis.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Fixture;
+
+final class SkipNotFromThis
+{
+    public function run()
+    {
+        $obj = new \DateTime('now');
+        $obj->format('Y-m-d');
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipNotPrivate.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipNotPrivate.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+
+class SkipNotPrivate
+{
+    public function run(Node $node)
+    {
+        if ($node instanceof MethodCall) {
+            $this->isCheckNotPrivate($node);
+        }
+    }
+
+    public function isCheckNotPrivate(Node $node)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipOptedOut.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipOptedOut.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Fixture;
+
+use PHPStan\Type\MixedType;
+
+class SkipOptedOut
+{
+    public function run(\PHPStan\Type\Type $type)
+    {
+        if ($type instanceof MixedType) {
+            return;
+        }
+
+        $this->isCheck($type);
+    }
+
+    private function isCheck(\PHPStan\Type\Type $type)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipParentNotIf.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipParentNotIf.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Fixture;
+
+use PhpParser\Node;
+
+final class SkipParentNotIf
+{
+    public function run(Node $node)
+    {
+        $this->execute($node);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipRecursive.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipRecursive.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use Rector\TypePerfect\Tests\Rules\PreferredClassRule\Fixture\SomeStaticCall;
+
+class SkipRecursive
+{
+    /**
+     * @param SomeStaticCall|MethodCall $node
+     */
+    public function processNode(Node $node): void
+    {
+        $this->run($node);
+    }
+
+    /**
+     * @param SomeStaticCall|MethodCall $node
+     */
+    private function run(Node $node): void
+    {
+        if ($node->name instanceof MethodCall) {
+            $this->run($node->name);
+        }
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipSameGeneric.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipSameGeneric.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Fixture;
+
+
+use Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Source\MyIterator;
+use Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Source\MyPreise;
+
+final class SkipSameGeneric
+{
+    protected function getPriceAndCalculateTableVM(): void
+    {
+
+        $prices = $this->getPricesForArticle();
+        $this->getAmounts($prices);
+    }
+
+    /**
+     * @param MyIterator<MyPreise> $prices
+     */
+    private function getAmounts(MyIterator $prices): void
+    {
+    }
+
+    /**
+     * @return MyIterator<MyPreise>
+     */
+    private function getPricesForArticle(): MyIterator
+    {
+        /** @var MyIterator<MyPreise> */
+        return new MyIterator();
+    }
+
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipVariadics.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Fixture/SkipVariadics.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Fixture;
+
+use PhpParser\Node;
+
+class SkipVariadics
+{
+    public function run(Node $node, Node $node2, Node $node3)
+    {
+        $arr = [$node, $node2, $node3];
+        $this->takesVariadic(...$arr);
+    }
+
+    private function takesVariadic(Node ...$node)
+    {
+
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/NarrowPrivateClassMethodParamTypeRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/NarrowPrivateClassMethodParamTypeRuleTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule;
+
+use Iterator;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Param;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\TypePerfect\Rules\NarrowPrivateClassMethodParamTypeRule;
+
+final class NarrowPrivateClassMethodParamTypeRuleTest extends RuleTestCase
+{
+    /**
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorsWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath, array $expectedErrorsWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorsWithLines);
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/SkipDuplicatedCallOfSameMethodWithComment.php', []];
+
+        yield [__DIR__ . '/Fixture/SkipCorrectUnionType.php', []];
+        yield [__DIR__ . '/Fixture/SkipRecursive.php', []];
+        yield [__DIR__ . '/Fixture/SkipMixed.php', []];
+        yield [__DIR__ . '/Fixture/SkipOptedOut.php', []];
+        yield [__DIR__ . '/Fixture/SkipNotFromThis.php', []];
+
+        yield [__DIR__ . '/Fixture/SkipParentNotIf.php', []];
+        yield [__DIR__ . '/Fixture/SkipNoArgs.php', []];
+        yield [__DIR__ . '/Fixture/SkipAlreadyCorrectType.php', []];
+        yield [__DIR__ . '/Fixture/SkipMayOverrideArg.php', []];
+        yield [__DIR__ . '/Fixture/SkipMultipleUsed.php', []];
+        yield [__DIR__ . '/Fixture/SkipNotPrivate.php', []];
+
+        $errorMessage = sprintf(NarrowPrivateClassMethodParamTypeRule::ERROR_MESSAGE, 1, MethodCall::class);
+        yield [__DIR__ . '/Fixture/Fixture.php', [[$errorMessage, 19]]];
+        yield [__DIR__ . '/Fixture/DifferentClassSameMethodCallName.php', [[$errorMessage, 25]]];
+
+        $argErrorMessage = sprintf(NarrowPrivateClassMethodParamTypeRule::ERROR_MESSAGE, 1, Arg::class);
+        $paramErrorMessage = sprintf(NarrowPrivateClassMethodParamTypeRule::ERROR_MESSAGE, 2, Param::class);
+        yield [__DIR__ . '/Fixture/DoubleShot.php', [[$argErrorMessage, 15], [$paramErrorMessage, 15]]];
+        yield [__DIR__ . '/Fixture/SkipGenericType.php', []];
+        yield [__DIR__ . '/Fixture/SkipAbstractBase.php', []];
+        yield [__DIR__ . '/Fixture/SkipVariadics.php', []];
+        yield [__DIR__ . '/Fixture/SkipSameGeneric.php', []];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../../config/extension.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NarrowPrivateClassMethodParamTypeRule::class);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Source/AnotherClassWithRun.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Source/AnotherClassWithRun.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Source;
+
+use PhpParser\Node;
+
+final class AnotherClassWithRun
+{
+    public function run(Node $node)
+    {
+        return $node;
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Source/ConceptBase.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Source/ConceptBase.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Source;
+
+
+abstract class ConceptBase
+{
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Source/ConceptImpl1.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Source/ConceptImpl1.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Source;
+
+class ConceptImpl1 extends ConceptBase
+{
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Source/MyIterator.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Source/MyIterator.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Source;
+
+/**
+ * @template T
+ */
+final class MyIterator
+{
+}

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Source/MyPreise.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/Source/MyPreise.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule\Source;
+
+class MyPreise
+{
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/ExplicitlyNullableParams.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/ExplicitlyNullableParams.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+final class ExplicitlyNullableParams
+{
+    public function test(
+        ?bool $bool = true,
+    ): bool
+    {
+        return $bool;
+    }
+
+    static public function run(): void
+    {
+        $skipDateTimeMix = new ExplicitlyNullableParams();
+        $skipDateTimeMix->test(false);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/FirstClassCallables/CallVariadics.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/FirstClassCallables/CallVariadics.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\FirstClassCallables;
+
+final class CallVariadics
+{
+    public function callMe(SomeCalledMethod $someCalledMethod)
+    {
+        $closure = $someCalledMethod->callMe(...);
+
+        $someCalledMethod->callMe(1000);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/FirstClassCallables/SomeCalledMethod.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/FirstClassCallables/SomeCalledMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\FirstClassCallables;
+
+final class SomeCalledMethod
+{
+    public function callMe($number)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/Generics/SkipPassedGenerics.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/Generics/SkipPassedGenerics.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\Generics;
+
+/**
+ * @template T
+ */
+class GenericA
+{
+}
+
+class User
+{
+    /** @param GenericA<string> $g */
+    public function doFoo(GenericA $g):void
+    {
+    }
+
+    /** @param GenericA<string> $g */
+    function doBar($g):void {
+        $this->doFoo($g);
+    }
+}
+

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/Generics/SkipSameGeneric.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/Generics/SkipSameGeneric.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\Generics;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\SkipSameGeneric\MyGroup;
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\SkipSameGeneric\MyIterator;
+
+final class SkipSameGeneric
+{
+    /**
+     * @param MyIterator<MyGroup> $_werbemasse
+     */
+    public function setWerbemasse($_werbemasse): void
+    {
+        $this->_werbemasse = $_werbemasse;
+    }
+}
+
+

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/HandleDefaultValue.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/HandleDefaultValue.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+class HandleDefaultValue {
+    public function takesUnionWithDifferentDefaultValue(
+        int|string $value = "hallo"
+    ): bool
+    {
+        return true;
+    }
+
+    public function takesUnionWithSameTypeDefaultValue(
+        int|string $value = 123
+    ): bool
+    {
+        return true;
+    }
+
+    static public function run(): void
+    {
+        $o = new HandleDefaultValue();
+        $o->takesUnionWithDifferentDefaultValue(1);
+
+        $o = new HandleDefaultValue();
+        $o->takesUnionWithSameTypeDefaultValue(1);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/PublicDoubleShot.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/PublicDoubleShot.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+final class PublicDoubleShot
+{
+    public function callMeTwice($number)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipApiMarked.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipApiMarked.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+use PhpParser\Node;
+
+final class SkipApiMarked
+{
+    /**
+     * @api
+     */
+    public function callNode(Node $node)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipCallable.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipCallable.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+final class SkipCallable
+{
+    public function map(callable $mapper): array
+    {
+        return [];
+    }
+
+    public function run()
+    {
+        $this->map(function () {});
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipClassStringPassed.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipClassStringPassed.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+final class SkipClassStringPassed
+{
+    public function resolve(string $className)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipClosure.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipClosure.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+final class SkipClosure
+{
+    public function map(\Closure $mapper): array
+    {
+        return [];
+    }
+
+    public function run()
+    {
+        $this->map(function () {});
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipDateTimeMix.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipDateTimeMix.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+final class SkipDateTimeMix
+{
+    public function markDate(
+        \DateTimeInterface $date
+    ): bool
+    {
+        return true;
+    }
+
+    static public function run(): void
+    {
+        $skipDateTimeMix = new SkipDateTimeMix();
+        $skipDateTimeMix->markDate(
+            new \DateTimeImmutable('15:30')
+        );
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipDefault.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipDefault.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+final class SkipDefault
+{
+    public function dontSetParamValue(
+        string $Id = ''
+    ): bool
+    {
+        return true;
+    }
+
+    static public function run(): void
+    {
+        $skipDefault = new SkipDefault();
+        $skipDefault->dontSetParamValue();
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipEnum.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipEnum.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\PickReasonEnum;
+
+class SkipEnum
+{
+    public function pick(PickReasonEnum $pickReasonEnum): void
+    {
+    }
+
+    public function run()
+    {
+        $this->pick(PickReasonEnum::BarcodeIssue);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipEqualUnionType.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipEqualUnionType.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+
+final class SkipEqualUnionType
+{
+    public function run(MethodCall|StaticCall $obj)
+    {
+    }
+
+    public function runTernary(StaticCall|MethodCall $obj)
+    {
+        return $obj instanceof StaticCall
+            ? $obj->class
+            : $obj->var;
+    }
+
+    public function runTernaryFlipped(StaticCall|MethodCall $obj)
+    {
+        return $obj instanceof MethodCall
+            ? $obj->var
+            : $obj->class;
+    }
+
+    /**
+     * @param Node[]|Node $node
+     */
+    public function runArrayTyped(array | Node $node)
+    {
+    }
+
+    /**
+     * @param array<Node>|Node $node
+     */
+    public function runArrayTyped2(array | Node $node)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipExpectedClassType.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipExpectedClassType.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\PassMeAsType;
+
+final class SkipExpectedClassType
+{
+    public function callMeWithClassType(PassMeAsType $passMeAsType)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipMixedAndString.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipMixedAndString.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+final class SkipMixedAndString
+{
+    public function resolve($value)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipNonPublicClassMethod.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipNonPublicClassMethod.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+final class SkipNonPublicClassMethod
+{
+    public function personInTree()
+    {
+        $this->callMe(1000);
+    }
+
+    private function callMe($number)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipNullableCompare.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipNullableCompare.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+use PhpParser\Node;
+
+final class SkipNullableCompare
+{
+    public function callNode(?Node $node)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipProperlyFilledParamType.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipProperlyFilledParamType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+final class SkipProperlyFilledParamType
+{
+    public function callMeTwice(int $number)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipResource.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipResource.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+final class SkipResource
+{
+    /**
+     * @param resource $resource
+     */
+    public function map($resource, string $name): void
+    {
+    }
+
+    public function run()
+    {
+        $resource = @fsockopen('100', 100);
+        $this->map($resource, 'name');
+
+
+        $resource = $this->getFileResource();
+        $this->map($resource, 'surname');
+    }
+
+    /**
+     * @return resource
+     */
+    private function getFileResource()
+    {
+        return fopen('file.txt', 'r');
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipSelf.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipSelf.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+class SkipSelf {
+    public function takesSelf(self $code): bool
+    {
+        return true;
+    }
+
+    static public function run(SkipSelf $self): void
+    {
+        $self->takesSelf(new SkipSelf());
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipThisPassedExactType.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipThisPassedExactType.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\ExpectedThisType\CallByThis;
+
+final class SkipThisPassedExactType
+{
+    public function run(CallByThis $obj)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipUsedInternallyForSecondType.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/SkipUsedInternallyForSecondType.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+use DateTime;
+use stdClass;
+
+final class SkipUsedInternallyForSecondType
+{
+    public function run(stdClass|DateTime $obj)
+    {
+    }
+
+    public function execute()
+    {
+        $this->run(new DateTime('now'));
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/ThisPassedFromInterface.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Fixture/ThisPassedFromInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\SomeInterface;
+
+final class ThisPassedFromInterface
+{
+    public function run(SomeInterface $obj)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/NarrowPublicClassMethodParamTypeRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/NarrowPublicClassMethodParamTypeRuleTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule;
+
+use Iterator;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\TypePerfect\Rules\NarrowPublicClassMethodParamTypeRule;
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\ExpectedThisType\CallByThisFromInterface;
+
+final class NarrowPublicClassMethodParamTypeRuleTest extends RuleTestCase
+{
+    /**
+     * @param string[] $filePaths
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorsWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(array $filePaths, array $expectedErrorsWithLines): void
+    {
+        $this->analyse($filePaths, $expectedErrorsWithLines);
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield [[__DIR__ . '/Fixture/Generics/SkipPassedGenerics.php'], []];
+
+        yield [[__DIR__ . '/Fixture/SkipDefault.php'], []];
+        yield [[__DIR__ . '/Fixture/SkipResource.php'], []];
+        yield [[__DIR__ . '/Fixture/SkipDateTimeMix.php'], []];
+        yield [[__DIR__ . '/Fixture/SkipNonPublicClassMethod.php'], []];
+
+        // skip first class callables as anything can be passed there
+        yield [[
+            __DIR__ . '/Fixture/FirstClassCallables/CallVariadics.php',
+            __DIR__ . '/Fixture/FirstClassCallables/SomeCalledMethod.php',
+        ], []];
+
+        // skip expected scalar type
+        yield [[
+            __DIR__ . '/Fixture/SkipProperlyFilledParamType.php',
+            __DIR__ . '/Source/ExpectedType/FirstTypedCaller.php',
+            __DIR__ . '/Source/ExpectedType/SecondTypedCaller.php',
+        ], []];
+
+        // skip expected object type
+        yield [[
+            __DIR__ . '/Fixture/SkipExpectedClassType.php',
+            __DIR__ . '/Source/ExpectedClassType/FirstClassTypedCaller.php',
+            __DIR__ . '/Source/ExpectedClassType/SecondClassTypedCaller.php',
+        ], []];
+
+        // skip class-string
+        yield [[
+            __DIR__ . '/Fixture/SkipClassStringPassed.php',
+            __DIR__ . '/Source/ExpectedClassString/FirstTypedCaller.php',
+            __DIR__ . '/Source/ExpectedClassString/SecondTypedCaller.php',
+        ], []];
+
+        // skip everything in case of values is mixed
+        yield [[
+            __DIR__ . '/Fixture/SkipMixedAndString.php',
+            __DIR__ . '/Source/MixedAndString/FirstCaller.php',
+            __DIR__ . '/Source/MixedAndString/SecondCaller.php',
+        ], []];
+
+        // skip int + string values
+        yield [[
+            __DIR__ . '/Fixture/SkipMixedAndString.php',
+            __DIR__ . '/Source/MixedAndString/FirstCaller.php',
+            __DIR__ . '/Source/MixedAndString/ThirdCaller.php',
+        ], []];
+
+        // skip nullable compare
+        yield [[
+            __DIR__ . '/Fixture/SkipNullableCompare.php',
+            __DIR__ . '/Source/NullableParam/FirstNullable.php',
+            __DIR__ . '/Source/NullableParam/SecondNullable.php',
+        ], []];
+
+        // skip api
+        yield [[
+            __DIR__ . '/Fixture/SkipApiMarked.php',
+            __DIR__ . '/Source/ExpectedNodeApi/CallWithProperty.php',
+        ], []];
+
+        // skip equal union type
+        yield [[
+            __DIR__ . '/Fixture/SkipEqualUnionType.php',
+            __DIR__ . '/Source/ExpectedUnion/CallUnionType.php',
+        ], []];
+
+        // skip equal union type flipped
+        yield [[
+            __DIR__ . '/Fixture/SkipEqualUnionType.php',
+            __DIR__ . '/Source/ExpectedUnion/CallUnionTypeFlipped.php',
+        ], []];
+
+        // skip equal union type ternary if else
+        yield [[
+            __DIR__ . '/Fixture/SkipEqualUnionType.php',
+            __DIR__ . '/Source/ExpectedUnion/CallUnionTypeTernaryIfElse.php',
+        ], []];
+
+        // skip equal union type ternary if else flipped
+        yield [[
+            __DIR__ . '/Fixture/SkipEqualUnionType.php',
+            __DIR__ . '/Source/ExpectedUnion/CallUnionTypeTernaryIfElseFlipped.php',
+        ], []];
+
+        // skip equal union type array typed
+        yield [[
+            __DIR__ . '/Fixture/SkipEqualUnionType.php',
+            __DIR__ . '/Source/ExpectedUnion/CallUnionArrayType.php',
+        ], []];
+
+        // skip this passed exact type
+        yield [[
+            __DIR__ . '/Fixture/SkipThisPassedExactType.php',
+            __DIR__ . '/Source/ExpectedThisType/CallByThis.php',
+        ], []];
+
+        // skip used internally for second type
+        yield [[
+            __DIR__ . '/Fixture/SkipUsedInternallyForSecondType.php',
+            __DIR__ . '/Source/ExpectedType/OnlyFirstTypeCalledOutside.php',
+        ], []];
+
+        $argErrorMessage = sprintf(NarrowPublicClassMethodParamTypeRule::ERROR_MESSAGE, 'int');
+        yield [[
+            __DIR__ . '/Fixture/PublicDoubleShot.php',
+            __DIR__ . '/Source/FirstCaller.php',
+            __DIR__ . '/Source/SecondCaller.php',
+        ], [[$argErrorMessage, 9]]];
+
+        // this passed from interface
+        $argErrorMessage = sprintf(
+            NarrowPublicClassMethodParamTypeRule::ERROR_MESSAGE,
+            CallByThisFromInterface::class
+        );
+        yield [[
+            __DIR__ . '/Fixture/ThisPassedFromInterface.php',
+            __DIR__ . '/Source/ExpectedThisType/CallByThisFromInterface.php',
+        ], [[$argErrorMessage, 11]]];
+
+        yield [[__DIR__ . '/Fixture/SkipSelf.php'], []];
+
+        yield [[__DIR__ . '/Fixture/SkipClosure.php'], []];
+
+        yield [[__DIR__ . '/Fixture/SkipCallable.php'], []];
+
+        yield [[__DIR__ . '/Fixture/SkipEnum.php'], []];
+
+        $argErrorMessage = sprintf(NarrowPublicClassMethodParamTypeRule::ERROR_MESSAGE, 'int');
+
+        yield [[__DIR__ . '/Fixture/HandleDefaultValue.php'], [[$argErrorMessage, 15]]];
+
+        $argErrorMessage = sprintf(NarrowPublicClassMethodParamTypeRule::ERROR_MESSAGE, 'bool');
+        yield [[__DIR__ . '/Fixture/ExplicitlyNullableParams.php'], [[$argErrorMessage, 9]]];
+
+        // skip generics
+        yield [[
+            __DIR__ . '/Fixture/Generics/SkipSameGeneric.php',
+            __DIR__ . '/Source/SkipSameGeneric/MyGroup.php',
+            __DIR__ . '/Source/SkipSameGeneric/MyIterator.php',
+            __DIR__ . '/Source/SkipSameGeneric/MyService.php',
+        ], []];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../../config/extension.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NarrowPublicClassMethodParamTypeRule::class);
+    }
+
+    /**
+     * Warning, just spent hour looking for why the test does not run :D This should be implicit part of the parent
+     * class.
+     *
+     * @return Collector[]
+     */
+    protected function getCollectors(): array
+    {
+        return self::getContainer()->getServicesByTag('phpstan.collector');
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedClassString/FirstTypedCaller.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedClassString/FirstTypedCaller.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\ExpectedClassString;
+
+use PHPStan\Reflection\ClassReflection;
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipClassStringPassed;
+
+final class FirstTypedCaller
+{
+    public function run(ClassReflection $classReflection)
+    {
+        $skipClassStringPassed = new SkipClassStringPassed();
+        $skipClassStringPassed->resolve($classReflection->getName());
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedClassString/SecondTypedCaller.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedClassString/SecondTypedCaller.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\ExpectedClassString;
+
+use PHPStan\Reflection\ClassReflection;
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipClassStringPassed;
+
+final class SecondTypedCaller
+{
+    public function run(ClassReflection $classReflection)
+    {
+        $skipClassStringPassed = new SkipClassStringPassed();
+        $skipClassStringPassed->resolve($classReflection->getName());
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedClassType/FirstClassTypedCaller.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedClassType/FirstClassTypedCaller.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\ExpectedClassType;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipExpectedClassType;
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\PassMeAsType;
+
+final class FirstClassTypedCaller
+{
+    public function goForIt(SkipExpectedClassType $skipExpectedClassType)
+    {
+        $knownType = new PassMeAsType();
+        $skipExpectedClassType->callMeWithClassType($knownType);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedClassType/SecondClassTypedCaller.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedClassType/SecondClassTypedCaller.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\ExpectedClassType;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipExpectedClassType;
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\PassMeAsType;
+
+final class SecondClassTypedCaller
+{
+    public function goForIt(SkipExpectedClassType $skipExpectedClassType)
+    {
+        $knownType = new PassMeAsType();
+        $skipExpectedClassType->callMeWithClassType($knownType);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedNodeApi/CallWithProperty.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedNodeApi/CallWithProperty.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\ExpectedNodeApi;
+
+use PhpParser\Node\Stmt\Property;
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipApiMarked;
+
+final class CallWithProperty
+{
+    public function run(SkipApiMarked $skipApiMarked, Property $property): void
+    {
+        $skipApiMarked->callNode($property);
+    }
+
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedThisType/CallByThis.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedThisType/CallByThis.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\ExpectedThisType;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipThisPassedExactType;
+
+final class CallByThis
+{
+    public function run(SkipThisPassedExactType $skipThisPassedExactType): void
+    {
+        $skipThisPassedExactType->run($this);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedThisType/CallByThisFromInterface.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedThisType/CallByThisFromInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\ExpectedThisType;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\ThisPassedFromInterface;
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\SomeInterface;
+
+final class CallByThisFromInterface implements SomeInterface
+{
+    public function run(ThisPassedFromInterface $thisPassedFromInterface): void
+    {
+        $thisPassedFromInterface->run($this);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedType/FirstTypedCaller.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedType/FirstTypedCaller.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\ExpectedType;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipProperlyFilledParamType;
+
+final class FirstTypedCaller
+{
+    public function goForIt(SkipProperlyFilledParamType $skipProperlyFilledParamType)
+    {
+        $skipProperlyFilledParamType->callMeTwice(100);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedType/OnlyFirstTypeCalledOutside.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedType/OnlyFirstTypeCalledOutside.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\ExpectedType;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipUsedInternallyForSecondType;
+use stdClass;
+
+final class OnlyFirstTypeCalledOutside
+{
+    public function run(SkipUsedInternallyForSecondType $skipUsedInternallyForSecondType)
+    {
+        $skipUsedInternallyForSecondType->run(new stdClass());
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedType/SecondTypedCaller.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedType/SecondTypedCaller.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\ExpectedType;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipProperlyFilledParamType;
+
+final class SecondTypedCaller
+{
+    public function goForIt(SkipProperlyFilledParamType $skipProperlyFilledParamType)
+    {
+        $skipProperlyFilledParamType->callMeTwice(100);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedUnion/CallUnionArrayType.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedUnion/CallUnionArrayType.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\ExpectedUnion;
+
+use PhpParser\Node;
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipEqualUnionType;
+
+final class CallUnionTypeArrayType
+{
+    public function run(SkipEqualUnionType $skipEqualUnionType, Node $node): void
+    {
+        /** @var Node[]|Node $node */
+        $node = rand(0, 1)
+            ? $node
+            : [$node];
+
+        $skipEqualUnionType->runArrayTyped($node);
+    }
+
+    public function run2(SkipEqualUnionType $skipEqualUnionType, Node $node): void
+    {
+        /** @var Node[]|Node $node */
+        $node = rand(0, 1)
+            ? $node
+            : [$node];
+
+        $skipEqualUnionType->runArrayTyped2($node);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedUnion/CallUnionType.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedUnion/CallUnionType.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\ExpectedUnion;
+
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipEqualUnionType;
+
+final class CallUnionType
+{
+    /**
+     * @param MethodCall[]|StaticCall[] $data
+     */
+    public function run(SkipEqualUnionType $skipEqualUnionType, array $data): void
+    {
+        foreach ($data as $value) {
+            $skipEqualUnionType->run($value);
+        }
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedUnion/CallUnionTypeFlipped.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedUnion/CallUnionTypeFlipped.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\ExpectedUnion;
+
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipEqualUnionType;
+
+final class CallUnionTypeFlipped
+{
+    /**
+     * @param StaticCall[]|MethodCall[] $data
+     */
+    public function run(SkipEqualUnionType $skipEqualUnionType, array $data): void
+    {
+        foreach ($data as $value) {
+            $skipEqualUnionType->run($value);
+        }
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedUnion/CallUnionTypeTernaryIfElse.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedUnion/CallUnionTypeTernaryIfElse.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\ExpectedUnion;
+
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipEqualUnionType;
+
+final class CallUnionTypeTernaryIfElse
+{
+    /**
+     * @param MethodCall[]|StaticCall[] $data
+     */
+    public function run(SkipEqualUnionType $skipEqualUnionType, array $data): void
+    {
+        foreach ($data as $value) {
+            $skipEqualUnionType->runTernary($value);
+        }
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedUnion/CallUnionTypeTernaryIfElseFlipped.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/ExpectedUnion/CallUnionTypeTernaryIfElseFlipped.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\ExpectedUnion;
+
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipEqualUnionType;
+
+final class CallUnionTypeTernaryIfElseFlipped
+{
+    /**
+     * @param MethodCall[]|StaticCall[] $data
+     */
+    public function run(SkipEqualUnionType $skipEqualUnionType, array $data): void
+    {
+        foreach ($data as $value) {
+            $skipEqualUnionType->runTernaryFlipped($value);
+        }
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/FirstCaller.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/FirstCaller.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\PublicDoubleShot;
+
+final class FirstCaller
+{
+    public function goForIt(PublicDoubleShot $publicDoubleShot)
+    {
+        $publicDoubleShot->callMeTwice(100);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/MixedAndString/FirstCaller.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/MixedAndString/FirstCaller.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\MixedAndString;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipMixedAndString;
+
+final class FirstCaller
+{
+    public function run(SkipMixedAndString $skipMixedAndString)
+    {
+        $skipMixedAndString->resolve('string');
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/MixedAndString/SecondCaller.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/MixedAndString/SecondCaller.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\MixedAndString;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipMixedAndString;
+
+final class SecondCaller
+{
+    public function run(SkipMixedAndString $skipMixedAndString, $mixedValue)
+    {
+        $skipMixedAndString->resolve($mixedValue);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/MixedAndString/ThirdCaller.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/MixedAndString/ThirdCaller.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\MixedAndString;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipMixedAndString;
+
+final class SecondCaller
+{
+    public function run(SkipMixedAndString $skipMixedAndString)
+    {
+        $skipMixedAndString->resolve(1000);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/NullableParam/FirstNullable.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/NullableParam/FirstNullable.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\NullableParam;
+
+use PhpParser\Node;
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipNullableCompare;
+
+final class FirstNullable
+{
+    public function run(SkipNullableCompare $skipNullableCompare, ?Node $node): void
+    {
+        $skipNullableCompare->callNode($node);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/NullableParam/SecondNullable.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/NullableParam/SecondNullable.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\NullableParam;
+
+use PhpParser\Node;
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\SkipNullableCompare;
+
+final class SecondNullable
+{
+    public function run(SkipNullableCompare $skipNullableCompare, ?Node $node): void
+    {
+        $skipNullableCompare->callNode($node);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/PassMeAsType.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/PassMeAsType.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source;
+
+final class PassMeAsType
+{
+
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/PickReasonEnum.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/PickReasonEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source;
+
+enum PickReasonEnum: string
+{
+    case BarcodeIssue = 'barcode_issue';
+    case EmptyLocation = 'empty_location';
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/SecondCaller.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/SecondCaller.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\PublicDoubleShot;
+
+final class SecondCaller
+{
+    public function goForIt(PublicDoubleShot $publicDoubleShot)
+    {
+        $publicDoubleShot->callMeTwice(100);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/SkipSameGeneric/MyGroup.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/SkipSameGeneric/MyGroup.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\SkipSameGeneric;
+
+final class MyGroup
+{
+
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/SkipSameGeneric/MyIterator.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/SkipSameGeneric/MyIterator.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\SkipSameGeneric;
+
+/**
+ * @template T
+ */
+final class MyIterator
+{
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/SkipSameGeneric/MyService.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/SkipSameGeneric/MyService.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source\SkipSameGeneric;
+
+use Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Fixture\Generics\SkipSameGeneric;
+
+final class MyService
+{
+
+    private SkipSameGeneric $articleModel;
+
+    private function populateCustomizationDimensions(int $spracheid): void
+    {
+        $this->articleModel->setWerbemasse($this->fetchCustomizationPositionsByArtidAndSprache());
+    }
+
+    /**
+     * @return MyIterator<MyGroup>
+     */
+    public function fetchCustomizationPositionsByArtidAndSprache(int $artid, int $spracheid): MyIterator
+    {
+    }
+
+}

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/SomeInterface.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/Source/SomeInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule\Source;
+
+interface SomeInterface
+{}

--- a/packages/type-perfect/tests/Rules/NarrowReturnObjectTypeRule/Fixture/SkipSomeContract.php
+++ b/packages/type-perfect/tests/Rules/NarrowReturnObjectTypeRule/Fixture/SkipSomeContract.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowReturnObjectTypeRule\Fixture;
+
+use PHPStan\Rules\Cast\EchoRule;
+use PHPStan\Rules\Rule;
+use Rector\TypePerfect\Tests\Rules\NarrowReturnObjectTypeRule\Source\SomeContract;
+
+final class SkipSomeContract implements SomeContract
+{
+    public function getRule(): Rule
+    {
+        return new EchoRule();
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowReturnObjectTypeRule/Fixture/SkipSpecificReturnType.php
+++ b/packages/type-perfect/tests/Rules/NarrowReturnObjectTypeRule/Fixture/SkipSpecificReturnType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowReturnObjectTypeRule\Fixture;
+
+use Rector\TypePerfect\Tests\Rules\NarrowReturnObjectTypeRule\Source\SpecificControl;
+
+final class SkipSpecificReturnType
+{
+    public function create(): SpecificControl
+    {
+        return new SpecificControl();
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowReturnObjectTypeRule/Fixture/SomeAbstractReturnType.php
+++ b/packages/type-perfect/tests/Rules/NarrowReturnObjectTypeRule/Fixture/SomeAbstractReturnType.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowReturnObjectTypeRule\Fixture;
+
+use Rector\TypePerfect\Tests\Rules\NarrowReturnObjectTypeRule\Source\AbstractControl;
+use Rector\TypePerfect\Tests\Rules\NarrowReturnObjectTypeRule\Source\SpecificControl;
+
+final class SomeAbstractReturnType
+{
+    public function create(): AbstractControl
+    {
+        return new SpecificControl();
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowReturnObjectTypeRule/NarrowReturnObjectTypeRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NarrowReturnObjectTypeRule/NarrowReturnObjectTypeRuleTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowReturnObjectTypeRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\TypePerfect\Rules\NarrowReturnObjectTypeRule;
+use Rector\TypePerfect\Tests\Rules\NarrowReturnObjectTypeRule\Source\SpecificControl;
+
+final class NarrowReturnObjectTypeRuleTest extends RuleTestCase
+{
+    /**
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorMessagesWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorMessagesWithLines);
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/SkipSpecificReturnType.php', []];
+        yield [__DIR__ . '/Fixture/SkipSomeContract.php', []];
+
+        $errorMessage = sprintf(NarrowReturnObjectTypeRule::ERROR_MESSAGE, SpecificControl::class);
+        yield [__DIR__ . '/Fixture/SomeAbstractReturnType.php', [[$errorMessage, 12]]];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../../config/extension.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NarrowReturnObjectTypeRule::class);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NarrowReturnObjectTypeRule/Source/AbstractControl.php
+++ b/packages/type-perfect/tests/Rules/NarrowReturnObjectTypeRule/Source/AbstractControl.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowReturnObjectTypeRule\Source;
+
+abstract class AbstractControl
+{
+}

--- a/packages/type-perfect/tests/Rules/NarrowReturnObjectTypeRule/Source/SomeContract.php
+++ b/packages/type-perfect/tests/Rules/NarrowReturnObjectTypeRule/Source/SomeContract.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowReturnObjectTypeRule\Source;
+
+use PHPStan\Rules\Rule;
+
+interface SomeContract
+{
+    public function getRule(): Rule;
+}

--- a/packages/type-perfect/tests/Rules/NarrowReturnObjectTypeRule/Source/SpecificControl.php
+++ b/packages/type-perfect/tests/Rules/NarrowReturnObjectTypeRule/Source/SpecificControl.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NarrowReturnObjectTypeRule\Source;
+
+final class SpecificControl extends AbstractControl
+{
+}

--- a/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Fixture/ArrayAccessOnNestedObject.php
+++ b/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Fixture/ArrayAccessOnNestedObject.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoArrayAccessOnObjectRule\Fixture;
+
+use Rector\TypePerfect\Tests\Rules\NoArrayAccessOnObjectRule\Source\ChildOfSomeClassWithArrayAccess;
+
+final class ArrayAccessOnNestedObject
+{
+    public function run()
+    {
+        $someClassWithArrayAcces = new ChildOfSomeClassWithArrayAccess();
+        return $someClassWithArrayAcces['key'];
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Fixture/ArrayAccessOnObject.php
+++ b/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Fixture/ArrayAccessOnObject.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoArrayAccessOnObjectRule\Fixture;
+
+use Rector\TypePerfect\Tests\Rules\NoArrayAccessOnObjectRule\Source\SomeClassWithArrayAccess;
+
+final class ArrayAccessOnObject
+{
+    public function run()
+    {
+        $someClassWithArrayAcces = new SomeClassWithArrayAccess();
+        return $someClassWithArrayAcces['key'];
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Fixture/SkipIterator.php
+++ b/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Fixture/SkipIterator.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoArrayAccessOnObjectRule\Fixture;
+
+final class SkipIterator
+{
+    public function run()
+    {
+        $iterator = new class extends \Iterator {};
+
+        return $iterator[0];
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Fixture/SkipOnArray.php
+++ b/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Fixture/SkipOnArray.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoArrayAccessOnObjectRule\Fixture;
+
+final class SkipOnArray
+{
+    public function run(array $values)
+    {
+        return $values['key'];
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Fixture/SkipSplFixedArray.php
+++ b/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Fixture/SkipSplFixedArray.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoArrayAccessOnObjectRule\Fixture;
+
+use SplFixedArray;
+
+final class SkipSplFixedArray
+{
+    public function run(SplFixedArray $splFixedArray)
+    {
+        return $splFixedArray[0];
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Fixture/SkipUriElement.php
+++ b/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Fixture/SkipUriElement.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoArrayAccessOnObjectRule\Fixture;
+
+use Symfony\Component\DomCrawler\Link;
+
+final class SkipUriElement
+{
+    public function run(Link $link)
+    {
+        return $link['href'];
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Fixture/SkipWeakMap.php
+++ b/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Fixture/SkipWeakMap.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoArrayAccessOnObjectRule\Fixture;
+
+use WeakMap;
+
+final class SkipWeakMap
+{
+    public function run(WeakMap $weakMap)
+    {
+        return $weakMap[0];
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Fixture/SkipXml.php
+++ b/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Fixture/SkipXml.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoArrayAccessOnObjectRule\Fixture;
+
+use SimpleXMLElement;
+
+final class SkipXml
+{
+    public function run(SimpleXMLElement $values)
+    {
+        return $values['key'];
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Fixture/SkipXmlElementForeach.php
+++ b/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Fixture/SkipXmlElementForeach.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoArrayAccessOnObjectRule\Fixture;
+
+use SimpleXMLElement;
+
+final class SkipXmlElementForeach
+{
+    public function run(SimpleXMLElement $simpleXMLElement)
+    {
+        foreach ($simpleXMLElement->children() as $name => $childElement) {
+            return isset($childElement['some']);
+        }
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/NoArrayAccessOnObjectRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/NoArrayAccessOnObjectRuleTest.php
@@ -29,6 +29,7 @@ final class NoArrayAccessOnObjectRuleTest extends RuleTestCase
         yield [__DIR__ . '/Fixture/SkipIterator.php', []];
         yield [__DIR__ . '/Fixture/SkipOnArray.php', []];
         yield [__DIR__ . '/Fixture/SkipSplFixedArray.php', []];
+        yield [__DIR__ . '/Fixture/SkipUriElement.php', []];
         yield [__DIR__ . '/Fixture/SkipWeakMap.php', []];
         yield [__DIR__ . '/Fixture/SkipXml.php', []];
         yield [__DIR__ . '/Fixture/SkipXmlElementForeach.php', []];

--- a/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/NoArrayAccessOnObjectRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/NoArrayAccessOnObjectRuleTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoArrayAccessOnObjectRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\TypePerfect\Rules\NoArrayAccessOnObjectRule;
+
+final class NoArrayAccessOnObjectRuleTest extends RuleTestCase
+{
+    /**
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorMessagesWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorMessagesWithLines);
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/ArrayAccessOnObject.php', [[NoArrayAccessOnObjectRule::ERROR_MESSAGE, 14]]];
+        yield [__DIR__ . '/Fixture/ArrayAccessOnNestedObject.php', [[NoArrayAccessOnObjectRule::ERROR_MESSAGE, 14]]];
+
+        yield [__DIR__ . '/Fixture/SkipIterator.php', []];
+        yield [__DIR__ . '/Fixture/SkipOnArray.php', []];
+        yield [__DIR__ . '/Fixture/SkipSplFixedArray.php', []];
+        yield [__DIR__ . '/Fixture/SkipWeakMap.php', []];
+        yield [__DIR__ . '/Fixture/SkipXml.php', []];
+        yield [__DIR__ . '/Fixture/SkipXmlElementForeach.php', []];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../../config/extension.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NoArrayAccessOnObjectRule::class);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Source/ChildOfSomeClassWithArrayAccess.php
+++ b/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Source/ChildOfSomeClassWithArrayAccess.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoArrayAccessOnObjectRule\Source;
+
+class ChildOfSomeClassWithArrayAccess extends SomeClassWithArrayAccess
+{
+}

--- a/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Source/SomeClassWithArrayAccess.php
+++ b/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Source/SomeClassWithArrayAccess.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoArrayAccessOnObjectRule\Source;
+
+use ArrayAccess;
+
+class SomeClassWithArrayAccess implements ArrayAccess
+{
+    public function offsetExists($offset)
+    {
+    }
+
+    public function offsetGet($offset)
+    {
+    }
+
+    public function offsetSet($offset, $value)
+    {
+    }
+
+    public function offsetUnset($offset)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Source/SomeClassWithSplFixedArray.php
+++ b/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/Source/SomeClassWithSplFixedArray.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoArrayAccessOnObjectRule\Source;
+
+use SplFixedArray;
+
+final class SomeClassWithSplFixedArray extends SplFixedArray
+{
+}

--- a/packages/type-perfect/tests/Rules/NoEmptyOnObjectRule/Fixture/EmptyOnObject.php
+++ b/packages/type-perfect/tests/Rules/NoEmptyOnObjectRule/Fixture/EmptyOnObject.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoEmptyOnObjectRule\Fixture;
+
+use stdClass;
+
+final class EmptyOnObject
+{
+    public function run()
+    {
+        $object = null;
+
+        if (mt_rand(0, 100)) {
+            $object = new stdClass();
+        }
+
+        if (!empty($object)) {
+            return $object;
+        }
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoEmptyOnObjectRule/Fixture/SkipEmptyOnArray.php
+++ b/packages/type-perfect/tests/Rules/NoEmptyOnObjectRule/Fixture/SkipEmptyOnArray.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoEmptyOnObjectRule\Fixture;
+
+final class SkipEmptyOnArray
+{
+    public function run(array $values)
+    {
+        if (!empty($values[9])) {
+            return $values[9];
+        }
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoEmptyOnObjectRule/Fixture/SkipEmptyOnArrayNestedOnObject.php
+++ b/packages/type-perfect/tests/Rules/NoEmptyOnObjectRule/Fixture/SkipEmptyOnArrayNestedOnObject.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoEmptyOnObjectRule\Fixture;
+
+use PhpParser\Node\Expr\MethodCall;
+
+final class SkipEmptyOnArrayNestedOnObject
+{
+    public function run(MethodCall $methodCall)
+    {
+        if (!empty($methodCall->args[9])) {
+            return $methodCall->args[9];
+        }
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoEmptyOnObjectRule/Fixture/SkipPhpDocType.php
+++ b/packages/type-perfect/tests/Rules/NoEmptyOnObjectRule/Fixture/SkipPhpDocType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoEmptyOnObjectRule\Fixture;
+
+/** @var SkipPhpDocType|null $x */
+if (!empty($x)) {
+    return $x;
+}
+
+class SkipPhpDocType {}

--- a/packages/type-perfect/tests/Rules/NoEmptyOnObjectRule/Fixture/SkipPossibleUndefinedVariable.php
+++ b/packages/type-perfect/tests/Rules/NoEmptyOnObjectRule/Fixture/SkipPossibleUndefinedVariable.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoIssetOnObjectRule\Fixture;
+
+final class SkipPossibleUndefinedVariable
+{
+    public function run(bool $condition)
+    {
+        if ($condition) {
+            $object = new \stdClass();
+        }
+
+        if (!empty($object)) {
+            $object->foo = 'bar';
+        }
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoEmptyOnObjectRule/NoEmptyOnObjectRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NoEmptyOnObjectRule/NoEmptyOnObjectRuleTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoEmptyOnObjectRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\TypePerfect\Rules\NoEmptyOnObjectRule;
+
+final class NoEmptyOnObjectRuleTest extends RuleTestCase
+{
+    /**
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorMessagesWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorMessagesWithLines);
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/EmptyOnObject.php', [[NoEmptyOnObjectRule::ERROR_MESSAGE, 19]]];
+
+        yield [__DIR__ . '/Fixture/SkipEmptyOnArray.php', []];
+        yield [__DIR__ . '/Fixture/SkipEmptyOnArrayNestedOnObject.php', []];
+        yield [__DIR__ . '/Fixture/SkipPossibleUndefinedVariable.php', []];
+        yield [__DIR__ . '/Fixture/SkipPhpDocType.php', []];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../../config/extension.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NoEmptyOnObjectRule::class);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoIssetOnObjectRule/Fixture/IssetOnObject.php
+++ b/packages/type-perfect/tests/Rules/NoIssetOnObjectRule/Fixture/IssetOnObject.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoIssetOnObjectRule\Fixture;
+
+use stdClass;
+
+final class IssetOnObject
+{
+    public function run()
+    {
+        $object = null;
+
+        if (mt_rand(0, 100)) {
+            $object = new stdClass();
+        }
+
+        if (isset($object)) {
+            return $object;
+        }
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoIssetOnObjectRule/Fixture/SkipIssetOnArray.php
+++ b/packages/type-perfect/tests/Rules/NoIssetOnObjectRule/Fixture/SkipIssetOnArray.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoIssetOnObjectRule\Fixture;
+
+final class SkipIssetOnArray
+{
+    public function run(array $values)
+    {
+        if (isset($values[9])) {
+            return $values[9];
+        }
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoIssetOnObjectRule/Fixture/SkipIssetOnArrayNestedOnObject.php
+++ b/packages/type-perfect/tests/Rules/NoIssetOnObjectRule/Fixture/SkipIssetOnArrayNestedOnObject.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoIssetOnObjectRule\Fixture;
+
+use PhpParser\Node\Expr\MethodCall;
+
+final class SkipIssetOnArrayNestedOnObject
+{
+    public function run(MethodCall $methodCall)
+    {
+        if (isset($methodCall->args[9])) {
+            return $methodCall->args[9];
+        }
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoIssetOnObjectRule/Fixture/SkipIssetOnPropertyFetch.php
+++ b/packages/type-perfect/tests/Rules/NoIssetOnObjectRule/Fixture/SkipIssetOnPropertyFetch.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoIssetOnObjectRule\Fixture;
+
+use Rector\TypePerfect\Tests\Rules\NoIssetOnObjectRule\Source\Foo;
+
+class SkipIssetOnPropertyFetch
+{
+	private Foo $foo;
+
+	public function sayHello(): void
+	{
+		$this->initializeFoo();
+
+		$this->foo->sayHello();
+	}
+
+	private function initializeFoo(): void
+	{
+		if (!isset($this->foo))
+		{
+			$this->foo = new Foo();
+		}
+	}
+}

--- a/packages/type-perfect/tests/Rules/NoIssetOnObjectRule/Fixture/SkipPhpDocType.php
+++ b/packages/type-perfect/tests/Rules/NoIssetOnObjectRule/Fixture/SkipPhpDocType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoIssetOnObjectRule\Fixture;
+
+/** @var SkipPhpDocType|null $x */
+if (isset($x)) {
+    return $x;
+}
+
+class SkipPhpDocType {}

--- a/packages/type-perfect/tests/Rules/NoIssetOnObjectRule/Fixture/SkipPossibleUndefinedVariable.php
+++ b/packages/type-perfect/tests/Rules/NoIssetOnObjectRule/Fixture/SkipPossibleUndefinedVariable.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoIssetOnObjectRule\Fixture;
+
+final class SkipIssetOnArrayNestedOnObject
+{
+    public function run(bool $condition)
+    {
+        if ($condition) {
+            $object = new \stdClass();
+        }
+
+        if (isset($object)) {
+            $object->foo = 'bar';
+        }
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoIssetOnObjectRule/NoIssetOnObjectRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NoIssetOnObjectRule/NoIssetOnObjectRuleTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoIssetOnObjectRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\TypePerfect\Rules\NoIssetOnObjectRule;
+
+final class NoIssetOnObjectRuleTest extends RuleTestCase
+{
+    /**
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorMessagesWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorMessagesWithLines);
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/IssetOnObject.php', [[NoIssetOnObjectRule::ERROR_MESSAGE, 19]]];
+
+        yield [__DIR__ . '/Fixture/SkipIssetOnArray.php', []];
+        yield [__DIR__ . '/Fixture/SkipIssetOnArrayNestedOnObject.php', []];
+        yield [__DIR__ . '/Fixture/SkipPossibleUndefinedVariable.php', []];
+        yield [__DIR__ . '/Fixture/SkipIssetOnPropertyFetch.php', []];
+        yield [__DIR__ . '/Fixture/SkipPhpDocType.php', []];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../../config/extension.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NoIssetOnObjectRule::class);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoIssetOnObjectRule/Source/Foo.php
+++ b/packages/type-perfect/tests/Rules/NoIssetOnObjectRule/Source/Foo.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoIssetOnObjectRule\Source;
+
+class Foo
+{
+	public function sayHello(): void
+	{
+		echo 'Hello';
+	}
+}

--- a/packages/type-perfect/tests/Rules/NoMixedMethodCallerRule/Fixture/MagicMethodName.php
+++ b/packages/type-perfect/tests/Rules/NoMixedMethodCallerRule/Fixture/MagicMethodName.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoMixedMethodCallerRule\Fixture;
+
+final class MagicMethodName
+{
+    public function run($someType, $magic)
+    {
+        $someType->$magic();
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoMixedMethodCallerRule/Fixture/SkipKnownCallerType.php
+++ b/packages/type-perfect/tests/Rules/NoMixedMethodCallerRule/Fixture/SkipKnownCallerType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoMixedMethodCallerRule\Fixture;
+
+use Rector\TypePerfect\Tests\Rules\NoMixedMethodCallerRule\Source\KnownType;
+
+final class SkipKnownCallerType
+{
+    public function run(KnownType $knownType)
+    {
+        $knownType->call();
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoMixedMethodCallerRule/Fixture/SkipMockObject.php
+++ b/packages/type-perfect/tests/Rules/NoMixedMethodCallerRule/Fixture/SkipMockObject.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoMixedMethodCallerRule\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipMockObject extends TestCase
+{
+    public function test()
+    {
+        $mock = $this->createMock(MagicMethodName::class);
+
+        $mock
+            ->method('run')
+            ->willReturn(true);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoMixedMethodCallerRule/Fixture/SkipPHPUnitMock.php
+++ b/packages/type-perfect/tests/Rules/NoMixedMethodCallerRule/Fixture/SkipPHPUnitMock.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoMixedMethodCallerRule\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Rector\TypePerfect\Tests\Rules\NoMixedMethodCallerRule\Source\SomeFinalClass;
+
+final class SkipPHPUnitMock extends TestCase
+{
+    public function test()
+    {
+        $someClassMock = $this->createMock(SomeFinalClass::class);
+
+        $someClassMock->expects($this->once())
+            ->method('some')
+            ->with($this->any())
+            ->willReturn(1000);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoMixedMethodCallerRule/Fixture/UnknownCallerType.php
+++ b/packages/type-perfect/tests/Rules/NoMixedMethodCallerRule/Fixture/UnknownCallerType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoMixedMethodCallerRule\Fixture;
+
+final class UnknownCallerType
+{
+    public function run($mixedType)
+    {
+        $mixedType->call();
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoMixedMethodCallerRule/NoMixedMethodCallerRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NoMixedMethodCallerRule/NoMixedMethodCallerRuleTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoMixedMethodCallerRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\TypePerfect\Rules\NoMixedMethodCallerRule;
+
+final class NoMixedMethodCallerRuleTest extends RuleTestCase
+{
+    /**
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorsWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath, array $expectedErrorsWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorsWithLines);
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/SkipKnownCallerType.php', []];
+        yield [__DIR__ . '/Fixture/SkipMockObject.php', []];
+        yield [__DIR__ . '/Fixture/SkipPHPUnitMock.php', []];
+
+        $errorMessage = sprintf(NoMixedMethodCallerRule::ERROR_MESSAGE, '$someType');
+        yield [__DIR__ . '/Fixture/MagicMethodName.php', [[$errorMessage, 11]]];
+
+        $errorMessage = sprintf(NoMixedMethodCallerRule::ERROR_MESSAGE, '$mixedType');
+        yield [__DIR__ . '/Fixture/UnknownCallerType.php', [[$errorMessage, 11]]];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../../config/extension.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NoMixedMethodCallerRule::class);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoMixedMethodCallerRule/Source/KnownType.php
+++ b/packages/type-perfect/tests/Rules/NoMixedMethodCallerRule/Source/KnownType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoMixedMethodCallerRule\Source;
+
+final class KnownType
+{
+    public function call()
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoMixedMethodCallerRule/Source/SomeFinalClass.php
+++ b/packages/type-perfect/tests/Rules/NoMixedMethodCallerRule/Source/SomeFinalClass.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rector\TypePerfect\Tests\Rules\NoMixedMethodCallerRule\Source;
+
+final class SomeFinalClass
+{
+    public function some()
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoMixedPropertyFetcherRule/Fixture/DynamicName.php
+++ b/packages/type-perfect/tests/Rules/NoMixedPropertyFetcherRule/Fixture/DynamicName.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoMixedPropertyFetcherRule\Fixture;
+
+final class DynamicName
+{
+    public function run($unknownType)
+    {
+        $unknownType->{$name};
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoMixedPropertyFetcherRule/Fixture/SkipDynamicNameWithKnownType.php
+++ b/packages/type-perfect/tests/Rules/NoMixedPropertyFetcherRule/Fixture/SkipDynamicNameWithKnownType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoMixedPropertyFetcherRule\Fixture;
+
+use Rector\TypePerfect\Tests\Rules\NoMixedPropertyFetcherRule\Source\KnownType;
+
+final class SkipDynamicNameWithKnownType
+{
+    public function runOnType(KnownType $knownType)
+    {
+        $knownType->{$name};
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoMixedPropertyFetcherRule/Fixture/SkipKnownFetcherType.php
+++ b/packages/type-perfect/tests/Rules/NoMixedPropertyFetcherRule/Fixture/SkipKnownFetcherType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoMixedPropertyFetcherRule\Fixture;
+
+use Rector\TypePerfect\Tests\Rules\NoMixedPropertyFetcherRule\Source\KnownType;
+
+final class SkipKnownFetcherType
+{
+    public function run(KnownType $knownType)
+    {
+        $knownType->name;
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoMixedPropertyFetcherRule/Fixture/UnknownPropertyFetcher.php
+++ b/packages/type-perfect/tests/Rules/NoMixedPropertyFetcherRule/Fixture/UnknownPropertyFetcher.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoMixedPropertyFetcherRule\Fixture;
+
+final class UnknownPropertyFetcher
+{
+    public function run($unknownType)
+    {
+        $unknownType->name;
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoMixedPropertyFetcherRule/NoMixedPropertyFetcherRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NoMixedPropertyFetcherRule/NoMixedPropertyFetcherRuleTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoMixedPropertyFetcherRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\TypePerfect\Rules\NoMixedPropertyFetcherRule;
+
+final class NoMixedPropertyFetcherRuleTest extends RuleTestCase
+{
+    /**
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorsWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath, array $expectedErrorsWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorsWithLines);
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/SkipDynamicNameWithKnownType.php', []];
+        yield [__DIR__ . '/Fixture/SkipKnownFetcherType.php', []];
+
+        $message = sprintf(NoMixedPropertyFetcherRule::ERROR_MESSAGE, '$unknownType');
+        yield [__DIR__ . '/Fixture/DynamicName.php', [[$message, 11]]];
+
+        $message = sprintf(NoMixedPropertyFetcherRule::ERROR_MESSAGE, '$unknownType');
+        yield [__DIR__ . '/Fixture/UnknownPropertyFetcher.php', [[$message, 11]]];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../../config/extension.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NoMixedPropertyFetcherRule::class);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoMixedPropertyFetcherRule/Source/KnownType.php
+++ b/packages/type-perfect/tests/Rules/NoMixedPropertyFetcherRule/Source/KnownType.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoMixedPropertyFetcherRule\Source;
+
+final class KnownType
+{
+    public $name;
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/AnInterface.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/AnInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Fixture;
+
+interface AnInterface
+{
+    public function execute(string $string, int $int);
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/AnInterfaceOther.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/AnInterfaceOther.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Fixture;
+
+use stdClass;
+
+interface AnInterfaceOther
+{
+    public function run(stdClass $stdClass);
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/HasDifferentParameterWithInterfaceMethod.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/HasDifferentParameterWithInterfaceMethod.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Fixture;
+
+class HasDifferentParameterWithInterfaceMethod implements AnInterface, AnInterfaceOther
+{
+    public function execute($string, $int)
+    {
+    }
+
+    public function run($stdClass)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/HasDifferentParameterWithParentMethod.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/HasDifferentParameterWithParentMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Fixture;
+
+class HasDifferentParameterWithParentMethod extends ParentClass
+{
+    public function execute($string, $int)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/ParentClass.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/ParentClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Fixture;
+
+class ParentClass
+{
+    public function execute(string $string, int $int)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/RemoveParentType.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/RemoveParentType.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Fixture;
+
+use Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Source\SomeRectorInterface;
+
+final class RemoveParentType implements SomeRectorInterface
+{
+    public function refactor($node)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipConstruct.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipConstruct.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Fixture;
+
+class SkipConstruct extends ParentConstructorClass
+{
+    public function __construct($someArg, $someOther)
+    {
+        parent::__construct('foo', 4);
+    }
+}
+
+class ParentConstructorClass
+{
+    public function __construct(string $string, int $int)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipHasSameParameterWithInterfaceMethod.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipHasSameParameterWithInterfaceMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Fixture;
+
+use stdClass;
+
+class SkipHasSameParameterWithInterfaceMethod implements AnInterface, AnInterfaceOther
+{
+    public function execute(string $string, int $int)
+    {
+    }
+
+    public function run(stdClass $stdClass)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipHasSameParameterWithParentMethod.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipHasSameParameterWithParentMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Fixture;
+
+class SkipHasSameParameterWithParentMethod extends ParentClass
+{
+    public function execute(string $string, int $int)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipIndirectRemoval.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipIndirectRemoval.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Fixture;
+
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+
+final class SkipIndirectRemoval extends PhpFileLoader
+{
+    /**
+     * @param string|null $type
+     */
+    public function load(mixed $resource, string $type = null): mixed
+    {
+        return null;
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipNoParent.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipNoParent.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Fixture;
+
+class SkipNoParent
+{
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipNoType.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipNoType.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Fixture;
+
+use Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Source\NoTypeInterface;
+
+final class SkipNoType implements NoTypeInterface
+{
+    public function noType($node)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipNotHasParentMethod.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipNotHasParentMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Fixture;
+
+class SkipNotHasParentMethod extends ParentClass
+{
+    public function run()
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipPhpDocType.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipPhpDocType.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Fixture;
+
+use Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Source\PhpDocType;
+
+final class SkipPhpDocType extends PhpDocType
+{
+    /**
+     * @param string|null $node
+     */
+    public function justPhpDocType($node = null)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipPresentType.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Fixture/SkipPresentType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Fixture;
+
+use Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Source\SomeNode;
+use Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Source\SomeRectorInterface;
+
+final class SkipPresentType implements SomeRectorInterface
+{
+    public function refactor(SomeNode $node)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/NoParamTypeRemovalRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/NoParamTypeRemovalRuleTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\TypePerfect\Rules\NoParamTypeRemovalRule;
+
+final class NoParamTypeRemovalRuleTest extends RuleTestCase
+{
+    /**
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorMessagesWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorMessagesWithLines);
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/SkipConstruct.php', []];
+        yield [__DIR__ . '/Fixture/SkipPhpDocType.php', []];
+        yield [__DIR__ . '/Fixture/SkipPresentType.php', []];
+        yield [__DIR__ . '/Fixture/SkipNoType.php', []];
+
+        yield [__DIR__ . '/Fixture/SkipIndirectRemoval.php', []];
+
+        yield [__DIR__ . '/Fixture/RemoveParentType.php', [[NoParamTypeRemovalRule::ERROR_MESSAGE, 11]]];
+
+        yield [__DIR__ . '/Fixture/SkipNoParent.php', []];
+        yield [__DIR__ . '/Fixture/SkipNotHasParentMethod.php', []];
+        yield [__DIR__ . '/Fixture/SkipHasSameParameterWithParentMethod.php', []];
+        yield [__DIR__ . '/Fixture/SkipHasSameParameterWithInterfaceMethod.php', []];
+
+        yield [
+            __DIR__ . '/Fixture/HasDifferentParameterWithParentMethod.php',
+            [[NoParamTypeRemovalRule::ERROR_MESSAGE, 9]],
+        ];
+        yield [
+            __DIR__ . '/Fixture/HasDifferentParameterWithInterfaceMethod.php',
+            [[NoParamTypeRemovalRule::ERROR_MESSAGE, 9], [NoParamTypeRemovalRule::ERROR_MESSAGE, 13]],
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../../config/extension.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NoParamTypeRemovalRule::class);
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Source/NoTypeInterface.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Source/NoTypeInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Source;
+
+interface NoTypeInterface
+{
+    public function noType($node);
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Source/PhpDocType.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Source/PhpDocType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Source;
+
+class PhpDocType
+{
+    /**
+     * @param string|null $value
+     */
+    public function justPhpDocType($node = null)
+    {
+    }
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Source/SomeNode.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Source/SomeNode.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Source;
+
+final class SomeNode
+{
+
+}

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Source/SomeRectorInterface.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/Source/SomeRectorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule\Source;
+
+interface SomeRectorInterface
+{
+    public function refactor(SomeNode $node);
+}

--- a/packages/type-perfect/tests/Rules/ReturnNullOverFalseRule/Fixture/CheckResultFromOtherMethod.php
+++ b/packages/type-perfect/tests/Rules/ReturnNullOverFalseRule/Fixture/CheckResultFromOtherMethod.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\ReturnNullOverFalseRule\Fixture;
+
+class Loader
+{
+    /**
+     * @return bool
+     */
+    public function exists(string $name)
+    {
+        if (!$this->loadFromDb($name)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function loadFromDb(string $name): ?array
+    {
+        if (mt_rand(1, 0)) {
+            return null;
+        }
+
+        return ['test' => 'foo'];
+    }
+}

--- a/packages/type-perfect/tests/Rules/ReturnNullOverFalseRule/Fixture/CheckResultFromOtherMethod2.php
+++ b/packages/type-perfect/tests/Rules/ReturnNullOverFalseRule/Fixture/CheckResultFromOtherMethod2.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\ReturnNullOverFalseRule\Fixture;
+
+class Entity
+{
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function __isset($name)
+    {
+        if (!$this->isPropertyVisible($name)) {
+            return false;
+        }
+
+        return isset($this->$name);
+    }
+
+    private function isPropertyVisible(string $name): bool
+    {
+        if (mt_rand(1, 0)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/packages/type-perfect/tests/Rules/ReturnNullOverFalseRule/Fixture/ReturnFalseOnly.php
+++ b/packages/type-perfect/tests/Rules/ReturnNullOverFalseRule/Fixture/ReturnFalseOnly.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\ReturnNullOverFalseRule\Fixture;
+
+final class ReturnFalseOnly
+{
+    public function run()
+    {
+        if (mt_rand(1, 0)) {
+            return 1000;
+        }
+
+        return false;
+    }
+}

--- a/packages/type-perfect/tests/Rules/ReturnNullOverFalseRule/Fixture/SkipReturnBool.php
+++ b/packages/type-perfect/tests/Rules/ReturnNullOverFalseRule/Fixture/SkipReturnBool.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\ReturnNullOverFalseRule\Fixture;
+
+final class SkipReturnBool
+{
+    public function run(): bool
+    {
+        if (mt_rand(1, 0)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/packages/type-perfect/tests/Rules/ReturnNullOverFalseRule/ReturnNullOverFalseRuleTest.php
+++ b/packages/type-perfect/tests/Rules/ReturnNullOverFalseRule/ReturnNullOverFalseRuleTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\TypePerfect\Tests\Rules\ReturnNullOverFalseRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\TypePerfect\Rules\ReturnNullOverFalseRule;
+
+final class ReturnNullOverFalseRuleTest extends RuleTestCase
+{
+    /**
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorMessagesWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorMessagesWithLines);
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/ReturnFalseOnly.php', [[ReturnNullOverFalseRule::ERROR_MESSAGE, 9]]];
+        yield [__DIR__ . '/Fixture/CheckResultFromOtherMethod.php', []];
+        yield [__DIR__ . '/Fixture/CheckResultFromOtherMethod2.php', []];
+
+        yield [__DIR__ . '/Fixture/SkipReturnBool.php', []];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/../../../config/extension.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ReturnNullOverFalseRule::class);
+    }
+}

--- a/packages/type-perfect/tests/SomeClass.php.inc
+++ b/packages/type-perfect/tests/SomeClass.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+final class SomeClass
+{
+    private string $name = 'not empty class';
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/packages/type-perfect/tests/config/included_services.neon
+++ b/packages/type-perfect/tests/config/included_services.neon
@@ -1,0 +1,2 @@
+includes:
+    - ../../config/services.neon

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,5 +8,6 @@
 >
     <testsuite name="all">
         <directory>tests</directory>
+        <directory>packages/type-perfect/tests</directory>
     </testsuite>
 </phpunit>


### PR DESCRIPTION
Merges [rector/type-perfect](https://github.com/rectorphp/type-perfect) into this repo as a combined package.

## Layout
- sources → `packages/type-perfect/src` (keeps `Rector\TypePerfect\` PSR-4 namespace)
- tests → `packages/type-perfect/tests` (`Rector\TypePerfect\Tests\`)
- rule wiring → `packages/type-perfect/config/extension.neon`

## composer.json
- autoload + autoload-dev: added `Rector\TypePerfect\` namespaces
- `extra.phpstan.includes` += `packages/type-perfect/config/extension.neon` (rules auto-load via extension-installer)
- require += `webmozart/assert` (real runtime dep)
- `nikic/php-parser` left out — provided transitively by phpstan (matches existing cda config)

## docs
- type-perfect README merged into `README.md`

## verify
- `phpunit.xml` testsuite += `packages/type-perfect/tests`
- 117 tests pass (22 coverage + 95 perfect)
- PHPStan: clean
- ECS: clean

Note: `ecs.php`/`rector.php`/`phpstan.neon` scan only `src`+`tests`, not `packages/` — type-perfect files are not yet under CI tooling.