### PR TITLE
[DX] Make type-perfect rules configurable, disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,15 @@ If you care about code quality and type safety, add these 10 rules to your CI.
 
 ## Install
 
+These rules ship with this package, so the install above is all you need:
+
 ```bash
-composer require rector/type-perfect --dev
+composer require tomasvotruba/type-coverage --dev
 ```
 
-*Note: Make sure you use [`phpstan/extension-installer`](https://github.com/phpstan/extension-installer#usage) to load the necessary service configs or include `vendor/rector/type-perfect/config/extension.neon` file.*
+*Note: Make sure you use [`phpstan/extension-installer`](https://github.com/phpstan/extension-installer#usage) to load the necessary service configs or include `vendor/tomasvotruba/type-coverage/packages/type-perfect/config/extension.neon` file.*
+
+*Migrating from `rector/type-perfect`? Remove it from your `composer.json`, the rules live here now.*
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -159,15 +159,7 @@ If you care about code quality and type safety, add these 10 rules to your CI.
 
 <br>
 
-## Install
-
-These rules ship with this package, so the install above is all you need:
-
-```bash
-composer require tomasvotruba/type-coverage --dev
-```
-
-*Note: Make sure you use [`phpstan/extension-installer`](https://github.com/phpstan/extension-installer#usage) to load the necessary service configs or include `vendor/tomasvotruba/type-coverage/packages/type-perfect/config/extension.neon` file.*
+These rules ship with the package [installed above](#install), there is nothing else to require.
 
 *Migrating from `rector/type-perfect`? Remove it from your `composer.json`, the rules live here now.*
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,20 @@ composer require rector/type-perfect --dev
 
 <br>
 
-There are 3 checks enabled out of the box. First one makes sure we don't miss a chance to use `instanceof` to make further code know about exact object type:
+Every rule is opt-in and disabled by default, so you can pick the ones that fit your project. See [Configure](#configure) below for the full list.
+
+The 3 checks below are the simplest ones to start with:
+
+```yaml
+parameters:
+    type_perfect:
+        no_isset_on_object: true
+        no_empty_on_object: true
+        no_array_access_on_object: true
+        no_param_type_removal: true
+```
+
+The first one makes sure we don't miss a chance to use `instanceof` to make further code know about exact object type:
 
 ```php
 private ?SomeType $someType = null;
@@ -202,7 +215,7 @@ if (! $this->someType instanceof SomeType) {
 
 <br>
 
-Second rule checks we use explicit object methods over magic array access:
+Second rule (`no_array_access_on_object`) checks we use explicit object methods over magic array access:
 
 ```php
 $article = new Article();
@@ -224,7 +237,7 @@ $id = $article->getId();
 
 <br>
 
-Last rule checks that all interface implementations follow the same method signature as the interface:
+Last rule (`no_param_type_removal`) checks that all interface implementations follow the same method signature as the interface:
 
 ```php
 interface SomeInterface
@@ -255,13 +268,19 @@ final class SomeClass implements SomeInterface
 
 ## Configure
 
-Next rules you can enable by configuration. We take them from the simplest to more powerful, in the same order we apply them on legacy projects.
+All rules are enabled by configuration and disabled by default. We take them from the simplest to more powerful, in the same order we apply them on legacy projects.
 
 You can enable them all at once:
 
 ```yaml
 parameters:
     type_perfect:
+        # the 3 checks above
+        no_isset_on_object: true
+        no_empty_on_object: true
+        no_array_access_on_object: true
+        no_param_type_removal: true
+
         no_mixed_property: true
         no_mixed_caller: true
         null_over_false: true

--- a/ecs.php
+++ b/ecs.php
@@ -5,11 +5,20 @@ declare(strict_types=1);
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 return ECSConfig::configure()
-    ->withPaths([__DIR__ . '/src', __DIR__ . '/tests'])
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+        __DIR__ . '/packages/type-perfect/src',
+        __DIR__ . '/packages/type-perfect/tests',
+    ])
     ->withRootFiles()
     ->withSkip([
         // these fixtures use PHP 8.3 features, we cannot check them wit lower versions
         __DIR__ . '/tests/Rules/ConstantTypeCoverageRule/Fixture/SkipKnownConstantType.php',
         __DIR__ . '/tests/Rules/ConstantTypeCoverageRule/Fixture/UnknownConstantType.php',
+
+        // fixtures assert exact error lines, formatting them would shift the lines
+        __DIR__ . '/packages/type-perfect/tests/*/Fixture/*',
+        __DIR__ . '/packages/type-perfect/tests/*/Source/*',
     ])
     ->withPreparedSets(common: true, psr12: true, cleanCode: true, symplify: true);

--- a/packages/type-perfect/config/extension.neon
+++ b/packages/type-perfect/config/extension.neon
@@ -9,6 +9,11 @@ parametersSchema:
         # replace for no_mixed
         no_mixed_property: bool()
         no_mixed_caller: bool()
+
+        no_param_type_removal: bool()
+        no_array_access_on_object: bool()
+        no_isset_on_object: bool()
+        no_empty_on_object: bool()
     ])
 
 # defaults
@@ -22,14 +27,25 @@ parameters:
         no_mixed_property: false
         no_mixed_caller: false
 
-rules:
-    # enabled by default
-    - Rector\TypePerfect\Rules\NoParamTypeRemovalRule
-    - Rector\TypePerfect\Rules\NoArrayAccessOnObjectRule
-    - Rector\TypePerfect\Rules\NoIssetOnObjectRule
-    - Rector\TypePerfect\Rules\NoEmptyOnObjectRule
+        no_param_type_removal: false
+        no_array_access_on_object: false
+        no_isset_on_object: false
+        no_empty_on_object: false
 
+rules:
     # turn on by the group name
+
+    # no_param_type_removal
+    - Rector\TypePerfect\Rules\NoParamTypeRemovalRule
+
+    # no_array_access_on_object
+    - Rector\TypePerfect\Rules\NoArrayAccessOnObjectRule
+
+    # no_isset_on_object
+    - Rector\TypePerfect\Rules\NoIssetOnObjectRule
+
+    # no_empty_on_object
+    - Rector\TypePerfect\Rules\NoEmptyOnObjectRule
 
     # narrow_param
     - Rector\TypePerfect\Rules\NarrowPublicClassMethodParamTypeRule

--- a/packages/type-perfect/src/Configuration.php
+++ b/packages/type-perfect/src/Configuration.php
@@ -18,6 +18,10 @@ final class Configuration
             $this->parameters['narrow_return'] = true;
             $this->parameters['no_mixed'] = true;
             $this->parameters['null_over_false'] = true;
+            $this->parameters['no_param_type_removal'] = true;
+            $this->parameters['no_array_access_on_object'] = true;
+            $this->parameters['no_isset_on_object'] = true;
+            $this->parameters['no_empty_on_object'] = true;
         }
     }
 
@@ -52,5 +56,25 @@ final class Configuration
     public function isNoFalsyReturnEnabled(): bool
     {
         return $this->parameters['null_over_false'] ?? false;
+    }
+
+    public function isNoParamTypeRemovalEnabled(): bool
+    {
+        return $this->parameters['no_param_type_removal'] ?? false;
+    }
+
+    public function isNoArrayAccessOnObjectEnabled(): bool
+    {
+        return $this->parameters['no_array_access_on_object'] ?? false;
+    }
+
+    public function isNoIssetOnObjectEnabled(): bool
+    {
+        return $this->parameters['no_isset_on_object'] ?? false;
+    }
+
+    public function isNoEmptyOnObjectEnabled(): bool
+    {
+        return $this->parameters['no_empty_on_object'] ?? false;
     }
 }

--- a/packages/type-perfect/src/Enum/Types/ResolvedTypes.php
+++ b/packages/type-perfect/src/Enum/Types/ResolvedTypes.php
@@ -6,8 +6,5 @@ namespace Rector\TypePerfect\Enum\Types;
 
 final class ResolvedTypes
 {
-    /**
-     * @var string
-     */
-    public const UNKNOWN_TYPES = 'unknown_types';
+    public const string UNKNOWN_TYPES = 'unknown_types';
 }

--- a/packages/type-perfect/src/Matcher/Collector/PublicClassMethodMatcher.php
+++ b/packages/type-perfect/src/Matcher/Collector/PublicClassMethodMatcher.php
@@ -13,7 +13,7 @@ final class PublicClassMethodMatcher
     /**
      * @var string[]
      */
-    private const SKIPPED_TYPES = [
+    private const array SKIPPED_TYPES = [
         'PHPUnit\Framework\TestCase',
         'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator',
     ];
@@ -25,13 +25,7 @@ final class PublicClassMethodMatcher
             return true;
         }
 
-        foreach (self::SKIPPED_TYPES as $skippedType) {
-            if ($classReflection->is($skippedType)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(self::SKIPPED_TYPES, fn (string $skippedType): bool => $classReflection->is($skippedType));
     }
 
     public function isUsedByParentClassOrInterface(ClassReflection $classReflection, string $methodName): bool
@@ -43,13 +37,7 @@ final class PublicClassMethodMatcher
             }
         }
 
-        foreach ($classReflection->getParents() as $parentClassReflection) {
-            if ($parentClassReflection->hasMethod($methodName)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any($classReflection->getParents(), fn (ClassReflection $parentClassReflection): bool => $parentClassReflection->hasMethod($methodName));
     }
 
     public function shouldSkipClassMethod(ClassMethod $classMethod): bool

--- a/packages/type-perfect/src/Rules/NarrowPrivateClassMethodParamTypeRule.php
+++ b/packages/type-perfect/src/Rules/NarrowPrivateClassMethodParamTypeRule.php
@@ -34,10 +34,7 @@ use Rector\TypePerfect\NodeFinder\MethodCallNodeFinder;
  */
 final readonly class NarrowPrivateClassMethodParamTypeRule implements Rule
 {
-    /**
-     * @var string
-     */
-    public const ERROR_MESSAGE = 'Parameter %d should use "%s" type as the only type passed to this method';
+    public const string ERROR_MESSAGE = 'Parameter %d should use "%s" type as the only type passed to this method';
 
     public function __construct(
         private Configuration $configuration,

--- a/packages/type-perfect/src/Rules/NarrowPublicClassMethodParamTypeRule.php
+++ b/packages/type-perfect/src/Rules/NarrowPublicClassMethodParamTypeRule.php
@@ -23,10 +23,7 @@ use Rector\TypePerfect\Enum\Types\ResolvedTypes;
  */
 final readonly class NarrowPublicClassMethodParamTypeRule implements Rule
 {
-    /**
-     * @var string
-     */
-    public const ERROR_MESSAGE = 'Parameters should have "%s" types as the only types passed to this method';
+    public const string ERROR_MESSAGE = 'Parameters should have "%s" types as the only types passed to this method';
 
     public function __construct(
         private Configuration $configuration
@@ -146,14 +143,19 @@ final readonly class NarrowPublicClassMethodParamTypeRule implements Rule
     }
 
     /**
-     * @param mixed[] $methodCallablesByFilePath
-     * @return mixed[]
+     * @param array<string, list<(array<string>|null)>> $methodCallablesByFilePath
+     * @return string[]
      */
     private function flattenCollectedData(array $methodCallablesByFilePath): array
     {
         $methodFirstClassCallables = [];
         foreach ($methodCallablesByFilePath as $methodCallables) {
             foreach ($methodCallables as $methodCallable) {
+                // the collector returns null for nodes it cannot resolve
+                if (! isset($methodCallable[0])) {
+                    continue;
+                }
+
                 $methodFirstClassCallables[] = $methodCallable[0];
             }
         }

--- a/packages/type-perfect/src/Rules/NarrowReturnObjectTypeRule.php
+++ b/packages/type-perfect/src/Rules/NarrowReturnObjectTypeRule.php
@@ -26,10 +26,7 @@ use Rector\TypePerfect\Reflection\MethodNodeAnalyser;
  */
 final readonly class NarrowReturnObjectTypeRule implements Rule
 {
-    /**
-     * @var string
-     */
-    public const ERROR_MESSAGE = 'Provide more specific return type "%s" over abstract one';
+    public const string ERROR_MESSAGE = 'Provide more specific return type "%s" over abstract one';
 
     public function __construct(
         private ReturnNodeFinder $returnNodeFinder,

--- a/packages/type-perfect/src/Rules/NoArrayAccessOnObjectRule.php
+++ b/packages/type-perfect/src/Rules/NoArrayAccessOnObjectRule.php
@@ -19,15 +19,12 @@ use Rector\TypePerfect\Configuration;
  */
 final readonly class NoArrayAccessOnObjectRule implements Rule
 {
-    /**
-     * @var string
-     */
-    public const ERROR_MESSAGE = 'Use explicit methods over array access on object';
+    public const string ERROR_MESSAGE = 'Use explicit methods over array access on object';
 
     /**
      * @var string[]
      */
-    private const ALLOWED_CLASSES = [
+    private const array ALLOWED_CLASSES = [
         'SplFixedArray',
         'SimpleXMLElement',
         'Iterator',
@@ -79,12 +76,6 @@ final readonly class NoArrayAccessOnObjectRule implements Rule
 
     private function isAllowedObjectType(ObjectType $objectType): bool
     {
-        foreach (self::ALLOWED_CLASSES as $allowedClass) {
-            if ($objectType->isInstanceOf($allowedClass)->yes()) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(self::ALLOWED_CLASSES, fn (string $allowedClass): bool => $objectType->isInstanceOf($allowedClass)->yes());
     }
 }

--- a/packages/type-perfect/src/Rules/NoArrayAccessOnObjectRule.php
+++ b/packages/type-perfect/src/Rules/NoArrayAccessOnObjectRule.php
@@ -11,12 +11,13 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
+use Rector\TypePerfect\Configuration;
 
 /**
  * @see \Rector\TypePerfect\Tests\Rules\NoArrayAccessOnObjectRule\NoArrayAccessOnObjectRuleTest
  * @implements Rule<ArrayDimFetch>
  */
-final class NoArrayAccessOnObjectRule implements Rule
+final readonly class NoArrayAccessOnObjectRule implements Rule
 {
     /**
      * @var string
@@ -37,6 +38,11 @@ final class NoArrayAccessOnObjectRule implements Rule
         'Symfony\Component\OptionsResolver\Options',
     ];
 
+    public function __construct(
+        private Configuration $configuration,
+    ) {
+    }
+
     /**
      * @return class-string<Node>
      */
@@ -51,6 +57,10 @@ final class NoArrayAccessOnObjectRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
+        if (! $this->configuration->isNoArrayAccessOnObjectEnabled()) {
+            return [];
+        }
+
         $varType = $scope->getType($node->var);
         if (! $varType instanceof ObjectType) {
             return [];

--- a/packages/type-perfect/src/Rules/NoEmptyOnObjectRule.php
+++ b/packages/type-perfect/src/Rules/NoEmptyOnObjectRule.php
@@ -18,10 +18,7 @@ use Rector\TypePerfect\Guard\EmptyIssetGuard;
  */
 final readonly class NoEmptyOnObjectRule implements Rule
 {
-    /**
-     * @var string
-     */
-    public const ERROR_MESSAGE = 'Use instanceof instead of empty() on object';
+    public const string ERROR_MESSAGE = 'Use instanceof instead of empty() on object';
 
     public function __construct(
         private EmptyIssetGuard $emptyIssetGuard,

--- a/packages/type-perfect/src/Rules/NoEmptyOnObjectRule.php
+++ b/packages/type-perfect/src/Rules/NoEmptyOnObjectRule.php
@@ -10,6 +10,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
+use Rector\TypePerfect\Configuration;
 use Rector\TypePerfect\Guard\EmptyIssetGuard;
 
 /**
@@ -23,7 +24,8 @@ final readonly class NoEmptyOnObjectRule implements Rule
     public const ERROR_MESSAGE = 'Use instanceof instead of empty() on object';
 
     public function __construct(
-        private EmptyIssetGuard $emptyIssetGuard
+        private EmptyIssetGuard $emptyIssetGuard,
+        private Configuration $configuration,
     ) {
     }
 
@@ -38,6 +40,10 @@ final readonly class NoEmptyOnObjectRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
+        if (! $this->configuration->isNoEmptyOnObjectEnabled()) {
+            return [];
+        }
+
         if ($this->emptyIssetGuard->isLegal($node->expr, $scope)) {
             return [];
         }

--- a/packages/type-perfect/src/Rules/NoIssetOnObjectRule.php
+++ b/packages/type-perfect/src/Rules/NoIssetOnObjectRule.php
@@ -10,6 +10,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
+use Rector\TypePerfect\Configuration;
 use Rector\TypePerfect\Guard\EmptyIssetGuard;
 
 /**
@@ -24,7 +25,8 @@ final readonly class NoIssetOnObjectRule implements Rule
     public const ERROR_MESSAGE = 'Use instanceof instead of isset() on object';
 
     public function __construct(
-        private EmptyIssetGuard $emptyIssetGuard
+        private EmptyIssetGuard $emptyIssetGuard,
+        private Configuration $configuration,
     ) {
     }
 
@@ -40,6 +42,10 @@ final readonly class NoIssetOnObjectRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
+        if (! $this->configuration->isNoIssetOnObjectEnabled()) {
+            return [];
+        }
+
         foreach ($node->vars as $var) {
             if ($this->emptyIssetGuard->isLegal($var, $scope)) {
                 continue;

--- a/packages/type-perfect/src/Rules/NoIssetOnObjectRule.php
+++ b/packages/type-perfect/src/Rules/NoIssetOnObjectRule.php
@@ -19,10 +19,7 @@ use Rector\TypePerfect\Guard\EmptyIssetGuard;
  */
 final readonly class NoIssetOnObjectRule implements Rule
 {
-    /**
-     * @var string
-     */
-    public const ERROR_MESSAGE = 'Use instanceof instead of isset() on object';
+    public const string ERROR_MESSAGE = 'Use instanceof instead of isset() on object';
 
     public function __construct(
         private EmptyIssetGuard $emptyIssetGuard,

--- a/packages/type-perfect/src/Rules/NoMixedMethodCallerRule.php
+++ b/packages/type-perfect/src/Rules/NoMixedMethodCallerRule.php
@@ -21,10 +21,7 @@ use Rector\TypePerfect\Configuration;
  */
 final readonly class NoMixedMethodCallerRule implements Rule
 {
-    /**
-     * @var string
-     */
-    public const ERROR_MESSAGE = 'Mixed variable in a `%s->...()` can skip important errors. Make sure the type is known';
+    public const string ERROR_MESSAGE = 'Mixed variable in a `%s->...()` can skip important errors. Make sure the type is known';
 
     public function __construct(
         private Printer $printer,

--- a/packages/type-perfect/src/Rules/NoMixedPropertyFetcherRule.php
+++ b/packages/type-perfect/src/Rules/NoMixedPropertyFetcherRule.php
@@ -20,10 +20,7 @@ use Rector\TypePerfect\Configuration;
  */
 final readonly class NoMixedPropertyFetcherRule implements Rule
 {
-    /**
-     * @var string
-     */
-    public const ERROR_MESSAGE = 'Mixed property fetch in a "%s->..." can skip important errors. Make sure the type is known';
+    public const string ERROR_MESSAGE = 'Mixed property fetch in a "%s->..." can skip important errors. Make sure the type is known';
 
     public function __construct(
         private Printer $printer,

--- a/packages/type-perfect/src/Rules/NoParamTypeRemovalRule.php
+++ b/packages/type-perfect/src/Rules/NoParamTypeRemovalRule.php
@@ -13,6 +13,7 @@ use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
+use Rector\TypePerfect\Configuration;
 use Rector\TypePerfect\Reflection\MethodNodeAnalyser;
 
 /**
@@ -27,7 +28,8 @@ final readonly class NoParamTypeRemovalRule implements Rule
     public const ERROR_MESSAGE = 'Removing parent param type is forbidden';
 
     public function __construct(
-        private MethodNodeAnalyser $methodNodeAnalyser
+        private MethodNodeAnalyser $methodNodeAnalyser,
+        private Configuration $configuration,
     ) {
     }
 
@@ -45,6 +47,10 @@ final readonly class NoParamTypeRemovalRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
+        if (! $this->configuration->isNoParamTypeRemovalEnabled()) {
+            return [];
+        }
+
         if ($node->params === []) {
             return [];
         }

--- a/packages/type-perfect/src/Rules/NoParamTypeRemovalRule.php
+++ b/packages/type-perfect/src/Rules/NoParamTypeRemovalRule.php
@@ -22,10 +22,7 @@ use Rector\TypePerfect\Reflection\MethodNodeAnalyser;
  */
 final readonly class NoParamTypeRemovalRule implements Rule
 {
-    /**
-     * @var string
-     */
-    public const ERROR_MESSAGE = 'Removing parent param type is forbidden';
+    public const string ERROR_MESSAGE = 'Removing parent param type is forbidden';
 
     public function __construct(
         private MethodNodeAnalyser $methodNodeAnalyser,

--- a/packages/type-perfect/src/Rules/ReturnNullOverFalseRule.php
+++ b/packages/type-perfect/src/Rules/ReturnNullOverFalseRule.php
@@ -23,9 +23,8 @@ final readonly class ReturnNullOverFalseRule implements Rule
 {
     /**
      * @api
-     * @var string
      */
-    public const ERROR_MESSAGE = 'Returning false in non return bool class method. Use null with type|null instead or add bool return type';
+    public const string ERROR_MESSAGE = 'Returning false in non return bool class method. Use null with type|null instead or add bool return type';
 
     private NodeFinder $nodeFinder;
 

--- a/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/NarrowPrivateClassMethodParamTypeRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NarrowPrivateClassMethodParamTypeRule/NarrowPrivateClassMethodParamTypeRuleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\TypePerfect\Tests\Rules\NarrowPrivateClassMethodParamTypeRule;
 
 use Iterator;
+use Override;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Param;
@@ -24,6 +25,9 @@ final class NarrowPrivateClassMethodParamTypeRuleTest extends RuleTestCase
         $this->analyse([$filePath], $expectedErrorsWithLines);
     }
 
+    /**
+     * @return Iterator<array<array<int, mixed>, mixed>>
+     */
     public static function provideData(): Iterator
     {
         yield [__DIR__ . '/Fixture/SkipDuplicatedCallOfSameMethodWithComment.php', []];
@@ -57,6 +61,7 @@ final class NarrowPrivateClassMethodParamTypeRuleTest extends RuleTestCase
     /**
      * @return string[]
      */
+    #[Override]
     public static function getAdditionalConfigFiles(): array
     {
         return [__DIR__ . '/../../../config/extension.neon'];

--- a/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/NarrowPublicClassMethodParamTypeRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NarrowPublicClassMethodParamTypeRule/NarrowPublicClassMethodParamTypeRuleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\TypePerfect\Tests\Rules\NarrowPublicClassMethodParamTypeRule;
 
 use Iterator;
+use Override;
 use PHPStan\Collectors\Collector;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
@@ -24,6 +25,9 @@ final class NarrowPublicClassMethodParamTypeRuleTest extends RuleTestCase
         $this->analyse($filePaths, $expectedErrorsWithLines);
     }
 
+    /**
+     * @return Iterator<array<array<int, array<int, mixed>>, mixed>>
+     */
     public static function provideData(): Iterator
     {
         yield [[__DIR__ . '/Fixture/Generics/SkipPassedGenerics.php'], []];
@@ -173,6 +177,7 @@ final class NarrowPublicClassMethodParamTypeRuleTest extends RuleTestCase
     /**
      * @return string[]
      */
+    #[Override]
     public static function getAdditionalConfigFiles(): array
     {
         return [__DIR__ . '/../../../config/extension.neon'];
@@ -189,6 +194,7 @@ final class NarrowPublicClassMethodParamTypeRuleTest extends RuleTestCase
      *
      * @return Collector[]
      */
+    #[Override]
     protected function getCollectors(): array
     {
         return self::getContainer()->getServicesByTag('phpstan.collector');

--- a/packages/type-perfect/tests/Rules/NarrowReturnObjectTypeRule/NarrowReturnObjectTypeRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NarrowReturnObjectTypeRule/NarrowReturnObjectTypeRuleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\TypePerfect\Tests\Rules\NarrowReturnObjectTypeRule;
 
 use Iterator;
+use Override;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -22,6 +23,9 @@ final class NarrowReturnObjectTypeRuleTest extends RuleTestCase
         $this->analyse([$filePath], $expectedErrorMessagesWithLines);
     }
 
+    /**
+     * @return Iterator<array<array<int, mixed>, mixed>>
+     */
     public static function provideData(): Iterator
     {
         yield [__DIR__ . '/Fixture/SkipSpecificReturnType.php', []];
@@ -34,6 +38,7 @@ final class NarrowReturnObjectTypeRuleTest extends RuleTestCase
     /**
      * @return string[]
      */
+    #[Override]
     public static function getAdditionalConfigFiles(): array
     {
         return [__DIR__ . '/../../../config/extension.neon'];

--- a/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/NoArrayAccessOnObjectRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NoArrayAccessOnObjectRule/NoArrayAccessOnObjectRuleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\TypePerfect\Tests\Rules\NoArrayAccessOnObjectRule;
 
 use Iterator;
+use Override;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -21,6 +22,9 @@ final class NoArrayAccessOnObjectRuleTest extends RuleTestCase
         $this->analyse([$filePath], $expectedErrorMessagesWithLines);
     }
 
+    /**
+     * @return Iterator<array<array<int, mixed>, mixed>>
+     */
     public static function provideData(): Iterator
     {
         yield [__DIR__ . '/Fixture/ArrayAccessOnObject.php', [[NoArrayAccessOnObjectRule::ERROR_MESSAGE, 14]]];
@@ -38,6 +42,7 @@ final class NoArrayAccessOnObjectRuleTest extends RuleTestCase
     /**
      * @return string[]
      */
+    #[Override]
     public static function getAdditionalConfigFiles(): array
     {
         return [__DIR__ . '/../../../config/extension.neon'];

--- a/packages/type-perfect/tests/Rules/NoEmptyOnObjectRule/NoEmptyOnObjectRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NoEmptyOnObjectRule/NoEmptyOnObjectRuleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\TypePerfect\Tests\Rules\NoEmptyOnObjectRule;
 
 use Iterator;
+use Override;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -21,6 +22,9 @@ final class NoEmptyOnObjectRuleTest extends RuleTestCase
         $this->analyse([$filePath], $expectedErrorMessagesWithLines);
     }
 
+    /**
+     * @return Iterator<array<array<int, mixed>, mixed>>
+     */
     public static function provideData(): Iterator
     {
         yield [__DIR__ . '/Fixture/EmptyOnObject.php', [[NoEmptyOnObjectRule::ERROR_MESSAGE, 19]]];
@@ -34,6 +38,7 @@ final class NoEmptyOnObjectRuleTest extends RuleTestCase
     /**
      * @return string[]
      */
+    #[Override]
     public static function getAdditionalConfigFiles(): array
     {
         return [__DIR__ . '/../../../config/extension.neon'];

--- a/packages/type-perfect/tests/Rules/NoIssetOnObjectRule/NoIssetOnObjectRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NoIssetOnObjectRule/NoIssetOnObjectRuleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\TypePerfect\Tests\Rules\NoIssetOnObjectRule;
 
 use Iterator;
+use Override;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -21,6 +22,9 @@ final class NoIssetOnObjectRuleTest extends RuleTestCase
         $this->analyse([$filePath], $expectedErrorMessagesWithLines);
     }
 
+    /**
+     * @return Iterator<array<array<int, mixed>, mixed>>
+     */
     public static function provideData(): Iterator
     {
         yield [__DIR__ . '/Fixture/IssetOnObject.php', [[NoIssetOnObjectRule::ERROR_MESSAGE, 19]]];
@@ -35,6 +39,7 @@ final class NoIssetOnObjectRuleTest extends RuleTestCase
     /**
      * @return string[]
      */
+    #[Override]
     public static function getAdditionalConfigFiles(): array
     {
         return [__DIR__ . '/../../../config/extension.neon'];

--- a/packages/type-perfect/tests/Rules/NoMixedMethodCallerRule/NoMixedMethodCallerRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NoMixedMethodCallerRule/NoMixedMethodCallerRuleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\TypePerfect\Tests\Rules\NoMixedMethodCallerRule;
 
 use Iterator;
+use Override;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -21,6 +22,9 @@ final class NoMixedMethodCallerRuleTest extends RuleTestCase
         $this->analyse([$filePath], $expectedErrorsWithLines);
     }
 
+    /**
+     * @return Iterator<array<array<int, mixed>, mixed>>
+     */
     public static function provideData(): Iterator
     {
         yield [__DIR__ . '/Fixture/SkipKnownCallerType.php', []];
@@ -37,6 +41,7 @@ final class NoMixedMethodCallerRuleTest extends RuleTestCase
     /**
      * @return string[]
      */
+    #[Override]
     public static function getAdditionalConfigFiles(): array
     {
         return [__DIR__ . '/../../../config/extension.neon'];

--- a/packages/type-perfect/tests/Rules/NoMixedPropertyFetcherRule/NoMixedPropertyFetcherRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NoMixedPropertyFetcherRule/NoMixedPropertyFetcherRuleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\TypePerfect\Tests\Rules\NoMixedPropertyFetcherRule;
 
 use Iterator;
+use Override;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -21,6 +22,9 @@ final class NoMixedPropertyFetcherRuleTest extends RuleTestCase
         $this->analyse([$filePath], $expectedErrorsWithLines);
     }
 
+    /**
+     * @return Iterator<array<array<int, mixed>, mixed>>
+     */
     public static function provideData(): Iterator
     {
         yield [__DIR__ . '/Fixture/SkipDynamicNameWithKnownType.php', []];
@@ -36,6 +40,7 @@ final class NoMixedPropertyFetcherRuleTest extends RuleTestCase
     /**
      * @return string[]
      */
+    #[Override]
     public static function getAdditionalConfigFiles(): array
     {
         return [__DIR__ . '/../../../config/extension.neon'];

--- a/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/NoParamTypeRemovalRuleTest.php
+++ b/packages/type-perfect/tests/Rules/NoParamTypeRemovalRule/NoParamTypeRemovalRuleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\TypePerfect\Tests\Rules\NoParamTypeRemovalRule;
 
 use Iterator;
+use Override;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -21,6 +22,9 @@ final class NoParamTypeRemovalRuleTest extends RuleTestCase
         $this->analyse([$filePath], $expectedErrorMessagesWithLines);
     }
 
+    /**
+     * @return Iterator<array<array<int, mixed>, mixed>>
+     */
     public static function provideData(): Iterator
     {
         yield [__DIR__ . '/Fixture/SkipConstruct.php', []];
@@ -50,6 +54,7 @@ final class NoParamTypeRemovalRuleTest extends RuleTestCase
     /**
      * @return string[]
      */
+    #[Override]
     public static function getAdditionalConfigFiles(): array
     {
         return [__DIR__ . '/../../../config/extension.neon'];

--- a/packages/type-perfect/tests/Rules/ReturnNullOverFalseRule/ReturnNullOverFalseRuleTest.php
+++ b/packages/type-perfect/tests/Rules/ReturnNullOverFalseRule/ReturnNullOverFalseRuleTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\TypePerfect\Tests\Rules\ReturnNullOverFalseRule;
 
 use Iterator;
+use Override;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -21,6 +22,9 @@ final class ReturnNullOverFalseRuleTest extends RuleTestCase
         $this->analyse([$filePath], $expectedErrorMessagesWithLines);
     }
 
+    /**
+     * @return Iterator<array<array<int, mixed>, mixed>>
+     */
     public static function provideData(): Iterator
     {
         yield [__DIR__ . '/Fixture/ReturnFalseOnly.php', [[ReturnNullOverFalseRule::ERROR_MESSAGE, 9]]];
@@ -33,6 +37,7 @@ final class ReturnNullOverFalseRuleTest extends RuleTestCase
     /**
      * @return string[]
      */
+    #[Override]
     public static function getAdditionalConfigFiles(): array
     {
         return [__DIR__ . '/../../../config/extension.neon'];

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,6 +14,8 @@ parameters:
     paths:
         - src
         - tests
+        - packages/type-perfect/src
+        - packages/type-perfect/tests
 
     type_coverage:
         # coverage
@@ -30,6 +32,17 @@ parameters:
 
         # used in tests
         - message: '#Public constant "TomasVotruba\\TypeCoverage\\(.*?)::ERROR_MESSAGE" is never#'
+        - message: '#Public constant "Rector\\TypePerfect\\(.*?)::ERROR_MESSAGE" is never#'
+
+        # inherited from rector/type-perfect, resolving these means rewriting the rule internals
+        -
+            identifier: phpstanApi.instanceofType
+            paths:
+                - packages/type-perfect/src
+        -
+            identifier: phpstanApi.instanceofAssumption
+            paths:
+                - packages/type-perfect/src
 
         # needed to access metadata about paths
         -

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,15 @@
 includes:
     - config/extension.neon
+    - packages/type-perfect/config/extension.neon
 
 parameters:
     level: 8
+
+    type_perfect:
+        no_param_type_removal: true
+        no_array_access_on_object: true
+        no_isset_on_object: true
+        no_empty_on_object: true
 
     paths:
         - src

--- a/rector.php
+++ b/rector.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ConstFetch\RemovePhpVersionIdCheckRector;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 
 return RectorConfig::configure()
-    ->withPaths([__DIR__ . '/src', __DIR__ . '/tests'])
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+        __DIR__ . '/packages/type-perfect/src',
+        __DIR__ . '/packages/type-perfect/tests',
+    ])
     ->withRootFiles()
     ->withPhpSets()
     ->withPreparedSets(
@@ -27,5 +33,9 @@ return RectorConfig::configure()
         RemovePhpVersionIdCheckRector::class => [
             // this package is downgraded, so PHP version checks are expected
             __DIR__ . '/src',
+        ],
+        StringClassNameToClassConstantRector::class => [
+            // allow-lists name classes from optional dev-only packages, they must stay strings
+            __DIR__ . '/packages/type-perfect/src',
         ],
     ]);


### PR DESCRIPTION
Follow-up to #68.

Four of the rules merged from `rector/type-perfect` were registered unconditionally:

* `NoParamTypeRemovalRule`
* `NoArrayAccessOnObjectRule`
* `NoIssetOnObjectRule`
* `NoEmptyOnObjectRule`

Installing the package immediately reported them, with no way to opt out short of `ignoreErrors`. Every other type-perfect rule (`narrow_param`, `narrow_return`, `no_mixed*`, `null_over_false`) is already opt-in, so this makes the set consistent.

## Change

Each of the 4 rules gets its own parameter, defaulting to `false`:

```diff
 parameters:
     type_perfect:
         narrow_param: false
         narrow_return: false
         no_mixed: false
         null_over_false: false
+        no_param_type_removal: false
+        no_array_access_on_object: false
+        no_isset_on_object: false
+        no_empty_on_object: false
```

Rules bail out early, same as the existing ones:

```diff
 public function processNode(Node $node, Scope $scope): array
 {
+    if (! $this->configuration->isNoIssetOnObjectEnabled()) {
+        return [];
+    }
+
     foreach ($node->vars as $var) {
```

To turn them on:

```yaml
parameters:
    type_perfect:
        no_isset_on_object: true
        no_empty_on_object: true
        no_array_access_on_object: true
        no_param_type_removal: true
```

## This repository

`phpstan.neon` now includes the type-perfect extension and enables all 4, so the rules keep running here and the package dogfoods them:

```diff
 includes:
     - config/extension.neon
+    - packages/type-perfect/config/extension.neon

 parameters:
     level: 8
+
+    type_perfect:
+        no_param_type_removal: true
+        no_array_access_on_object: true
+        no_isset_on_object: true
+        no_empty_on_object: true
```

## README

The "3 checks enabled out of the box" section now states the rules are opt-in and shows the config to enable them; the "enable them all at once" block lists the new keys.

## Note

No unit test for the defaults: `Configuration` force-enables every flag when `PHPUNIT_COMPOSER_INSTALL` is defined (pre-existing behaviour, so rule tests can run), which makes "off by default" untestable from inside PHPUnit. The new flags were added to that same list so the existing rule tests keep passing.
