### PR TITLE
Bump symfony/dom-crawler to ^8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "tomasvotruba/unused-public": "^2.2",
         "rector/jack": "^1.0",
         "shipmonk/composer-dependency-analyser": "^1.8",
-        "symfony/dom-crawler": "^7.4"
+        "symfony/dom-crawler": "^8.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Only dev dependency with a new major available.

```diff
 "require-dev": {
-    "symfony/dom-crawler": "^7.4"
+    "symfony/dom-crawler": "^8.1"
 }
```

`symfony/dom-crawler` 8.1 requires PHP >= 8.2, so it fits the package's `php: ^8.4`.

Lock-file only (not tracked here): `phpstan/phpstan` 2.2.6 → 2.2.7, `phpunit/phpunit` 13.2.5 → 13.2.6 — both already inside existing constraints.