### PR TITLE
Full dev dependency upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "rector/rector": "^2.5",
         "tracy/tracy": "^2.12",
         "tomasvotruba/unused-public": "^2.2",
-        "rector/jack": "^1.0",
+        "rector/jack": "^1.1",
         "shipmonk/composer-dependency-analyser": "^1.8",
         "symfony/dom-crawler": "^8.1"
     },


### PR DESCRIPTION
Went through every `require-dev` entry against the newest stable release on Packagist. All of them already resolve to the latest stable, so this is the only constraint that was behind its installed version:

```diff
 "require-dev": {
-    "rector/jack": "^1.0",
+    "rector/jack": "^1.1",
 }
```

## State after this PR

| package | constraint | installed | latest stable |
| --- | --- | --- | --- |
| phpstan/extension-installer | ^1.4 | 1.4.3 | 1.4.3 |
| phpunit/phpunit | ^13.2 | 13.2.6 | 13.2.6 |
| symplify/easy-coding-standard | ^13.2 | 13.2.17 | 13.2.17 |
| rector/rector | ^2.5 | 2.5.8 | 2.5.8 |
| tracy/tracy | ^2.12 | 2.12.0 | 2.12.0 |
| tomasvotruba/unused-public | ^2.2 | 2.2.1 | 2.2.1 |
| rector/jack | ^1.1 | 1.1.1 | 1.1.1 |
| shipmonk/composer-dependency-analyser | ^1.8 | 1.8.4 | 1.8.4 |
| symfony/dom-crawler | ^8.1 | 8.1.1 | 8.1.1 |

No new major is available for any of them. `symfony/dom-crawler` went to `^8.1` in #70.

Lock file is unchanged (`Nothing to modify in lock file`) and is not tracked in this repo anyway.