### PR TITLE
Drop deprecated symplify prepared set from ecs.php

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -21,4 +21,4 @@ return ECSConfig::configure()
         __DIR__ . '/packages/type-perfect/tests/*/Fixture/*',
         __DIR__ . '/packages/type-perfect/tests/*/Source/*',
     ])
-    ->withPreparedSets(common: true, psr12: true, cleanCode: true, symplify: true);
+    ->withPreparedSets(common: true, psr12: true, cleanCode: true);


### PR DESCRIPTION
Every ECS run printed this twice:

```
PHP Deprecated:  The "symplify" set is deprecated. Its rules now live in the "common" sets - use
->withPreparedSets(common: true) or the matching ->withDocblockLevel()/->withSpacesLevel()/->withArrayLevel()
methods instead. in vendor/symplify/easy-coding-standard/src/Configuration/ECSConfigBuilder.php on line 283
```

```diff
-    ->withPreparedSets(common: true, psr12: true, cleanCode: true, symplify: true);
+    ->withPreparedSets(common: true, psr12: true, cleanCode: true);
```

## No rules are lost

`common: true` was already enabled, and in current ECS the `symplify` flag adds no sets at all — the branch only raises the deprecation:

```php
// vendor/symplify/easy-coding-standard/src/Configuration/ECSConfigBuilder.php:281
if ($symplify) {
    // soft-deprecated: rules moved to the "common" sets, still loaded for backward compatibility
    trigger_error('The "symplify" set is deprecated. ...', \E_USER_DEPRECATED);
}
```

Compare with every other flag in that method, which pushes onto `$this->sets[]`. So the argument was already a no-op plus a warning.

## Verified

`vendor/bin/ecs check --fix` after the change modifies no file — the ruleset is identical, only the deprecation output is gone.