### PR TITLE
Add manual install instructions, merge type-perfect config into main extension.neon

### DIFF
--- a/.github/workflows/downgraded_release.yaml
+++ b/.github/workflows/downgraded_release.yaml
@@ -25,11 +25,12 @@ jobs:
             -   run: composer install --ansi
 
             # downgrade /src to PHP 7.2
-            -   run: vendor/bin/rector process src --config build/rector-downgrade-php-72.php --ansi
-            -   run: vendor/bin/ecs check src --fix --ansi
+            -   run: vendor/bin/rector process src packages/type-perfect/src --config build/rector-downgrade-php-72.php --ansi
+            -   run: vendor/bin/ecs check src packages/type-perfect/src --fix --ansi
 
             # clear the dev files, the vendor is not shipped as this is a phpstan extension
             -   run: rm -rf vendor tests ecs.php phpstan.neon phpunit.xml rector.php composer.lock .gitignore .editorconfig
+            -   run: rm -rf packages/type-perfect/tests
 
             # remove the original .github, to fully override it with the target repository one below
             -   run: rm -rf .github
@@ -50,7 +51,7 @@ jobs:
                     token: ${{ secrets.WORKFLOWS_TOKEN }}
 
             # remove remote files, to avoid piling up dead code in remote repository
-            -   run: rm -rf remote-repository/src remote-repository/config remote-repository/.github
+            -   run: rm -rf remote-repository/src remote-repository/config remote-repository/packages remote-repository/.github
 
             # copy the downgraded code to the remote repository
             -   run: rsync -a --exclude .git --exclude remote-repository ./ remote-repository/

--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ The package is available on PHP 7.2+.
 
 With [PHPStan extension installer](https://github.com/phpstan/extension-installer), everything is ready to run.
 
+Without it, include both config files manually:
+
+```yaml
+# phpstan.neon
+includes:
+    - vendor/tomasvotruba/type-coverage/config/extension.neon
+    - vendor/tomasvotruba/type-coverage/packages/type-perfect/config/extension.neon
+```
+
+<br>
+
 Enable each item on their own:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -83,13 +83,12 @@ The package is available on PHP 7.2+.
 
 With [PHPStan extension installer](https://github.com/phpstan/extension-installer), everything is ready to run.
 
-Without it, include both config files manually:
+Without it, include the config manually:
 
 ```yaml
 # phpstan.neon
 includes:
     - vendor/tomasvotruba/type-coverage/config/extension.neon
-    - vendor/tomasvotruba/type-coverage/packages/type-perfect/config/extension.neon
 ```
 
 <br>

--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -6,11 +6,13 @@
     "keywords": ["static analysis", "phpstan-extension"],
     "require": {
         "php": ">=7.2",
-        "phpstan/phpstan": "^1.8 || ^2.0"
+        "phpstan/phpstan": "^1.8 || ^2.0",
+        "webmozart/assert": "^1.11"
     },
     "autoload": {
         "psr-4": {
-            "TomasVotruba\\TypeCoverage\\": "src"
+            "TomasVotruba\\TypeCoverage\\": "src",
+            "Rector\\TypePerfect\\": "packages/type-perfect/src"
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,7 @@
     "extra": {
         "phpstan": {
             "includes": [
-                "config/extension.neon",
-                "packages/type-perfect/config/extension.neon"
+                "config/extension.neon"
             ]
         }
     }

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -1,3 +1,6 @@
+includes:
+    - ../packages/type-perfect/config/extension.neon
+
 parametersSchema:
     # see https://doc.nette.org/en/schema for configuration
     type_coverage: structure([

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,5 @@
 includes:
     - config/extension.neon
-    - packages/type-perfect/config/extension.neon
 
 parameters:
     level: 8


### PR DESCRIPTION
Closes #74

README only documented the [PHPStan extension installer](https://github.com/phpstan/extension-installer) path, so users without it had no way to know which config files to include.

Now a single include is enough — `config/extension.neon` pulls the Type Perfect config itself:

```yaml
# phpstan.neon
includes:
    - vendor/tomasvotruba/type-coverage/config/extension.neon
```

```diff
 # config/extension.neon
+includes:
+    - ../packages/type-perfect/config/extension.neon
+
 parametersSchema:
```

The second entry is dropped from `extra.phpstan.includes` in `composer.json` and from the local `phpstan.neon`, so the extension installer path loads each config exactly once.

### Downgraded release

`config/extension.neon` now references Type Perfect rules, so the downgraded `anywherephp/type-coverage` build has to ship them too:

* `packages/type-perfect/src` is downgraded to PHP 7.2 alongside `src`
* `build/target-repository/composer.json` autoloads `Rector\TypePerfect\` and requires `webmozart/assert` (used by `MethodCallNodeFinder`)
* `packages/type-perfect/tests` is stripped, and stale `packages` are cleared in the remote repository
